### PR TITLE
[AUDIO-HAL] [URGENT] hal: audio_extn: Enable building OSS only libhdmipassthru

### DIFF
--- a/hal/audio_extn/Android.mk
+++ b/hal/audio_extn/Android.mk
@@ -569,11 +569,9 @@ LOCAL_CFLAGS += \
     -Wall \
     -Werror \
     -Wno-unused-function \
-    -Wno-unused-variable \
-    -DDTSHD_PARSER_ENABLED
+    -Wno-unused-variable
 
 LOCAL_SHARED_LIBRARIES := \
-    libaudioparsers \
     libaudioroute \
     libaudioutils \
     libcutils \
@@ -582,6 +580,11 @@ LOCAL_SHARED_LIBRARIES := \
     liblog \
     libtinyalsa \
     libtinycompress
+
+ifeq ($(TARGET_COMPILE_WITH_PROPRIETARY_PARSERS),true)
+LOCAL_CFLAGS += -DDTSHD_PARSER_ENABLED
+LOCAL_SHARED_LIBRARIES += libaudioparsers
+endif
 
 LOCAL_C_INCLUDES := \
     $(PRIMARY_HAL_PATH) \


### PR DESCRIPTION
This library passes through the audio to the HDMI "as it is",
but there is an ifdef "DTSHD_PARSER_ENABLED" that, when enabled,
adds a dependency on proprietary audio_parsers.h header and
libaudioparsers, breaking opensource builds.

Disable the DTS HD passthrough by default for this library and
make it possible to enable it (with its proprietary requirements)
through the env variable TARGET_COMPILE_WITH_PROPRIETARY_PARSERS.