### PR TITLE
[AUDIO-PRIMARY] [Q-MR1] hal: platform_info: Fall back to Pixel audio_platform_info if error

### DIFF
--- a/hal/platform_info.c
+++ b/hal/platform_info.c
@@ -1462,6 +1462,14 @@ int platform_info_init(const char *filename, void *platform, caller_t caller_typ
     section = ROOT;
 
     if (!file) {
+        ALOGD("%s: Failed to open %s, trying to fall back to %s",
+              __func__, platform_info_file_name, PLATFORM_INFO_XML_PATH);
+        strlcpy(platform_info_file_name, PLATFORM_INFO_XML_PATH,
+                MIXER_PATH_MAX_LENGTH);
+        file = fopen(platform_info_file_name, "r");
+    }
+
+    if (!file) {
         ALOGD("%s: Failed to open %s, using defaults.",
             __func__, platform_info_file_name);
         ret = -ENODEV;


### PR DESCRIPTION
On some platforms, the audio_platform_info.xml file gets renamed
in many very creative ways.
If someone wants to stay clean, that someone is being forced into
finding what kind of creative names the HAL wants for the specific
sound card combination on the device, which is tricky and really
not an immediate nor the best way to do it: after all, if you are
bringing up audio for a project, you're not pushing configurations
that don't belong to that specific project, so why the... :)))

For this reason, introduce a fallback mechanism so that if the
Qualcomm creative suffix to "audio_platform_info" is not valid or
the developer hasn't played the find-the-name game, try to read
the standard "audio_platform_info.xml" file, as per Google's
guidelines.

Tested on Sony SDM630 Nile Pioneer DSDS