### PR TITLE
[CAF Audio] cirrus: Switch to MiscTa Wrapper over HIDL

### DIFF
--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -92,7 +92,7 @@ struct cirrus_playback_session {
 };
 
 /* TA handling */
-#define LIB_MISCTA	"libmiscta.so"
+#define LIB_MISCTA	"libMiscTaWrapper.so"
 #define TA_DEBUG 1
 
 /* TA functions */


### PR DESCRIPTION
Fixes https://github.com/sonyxperiadev/bug_tracker/issues/617

We are not the first to hit permission limitations on the TA daemon socket, in our case without the ability to add the appropriate group (`system`) to the AOSP audioserver library this HAL is loaded into.  Fortunately our ODM image provides a MiscTa wrapper that uses binder under the hood to offload the actual miscta calls (and permission burden that comes with it) to a separate service.  This wrapper exposes the exact same C interface as libmsicta.so making it a drop-in replacement (as intended).

Thanks @paulbouchara for testing while I'm not close to my PDX201!
