### PR TITLE
hal: Remove deprecated libraries from Android.mk

### DIFF
--- a/hal/Android.mk
+++ b/hal/Android.mk
@@ -141,9 +141,7 @@ LOCAL_SHARED_LIBRARIES := \
     libdl \
     libaudioutils \
     libexpat \
-    libhwbinder \
     libhidlbase \
-    libhidltransport \
     libprocessgroup \
     libutils
 
@@ -359,7 +357,7 @@ endif
 #    LOCAL_SRC_FILES += audio_extn/auto_hal.c
 #endif
 
-LOCAL_SHARED_LIBRARIES += libbase libhidlbase libhwbinder libutils android.hardware.power@1.2 liblog
+LOCAL_SHARED_LIBRARIES += libbase libhidlbase libutils android.hardware.power@1.2 liblog
 LOCAL_SRC_FILES += audio_perf.cpp
 
 ifeq ($(strip $(AUDIO_FEATURE_ENABLED_FM_TUNER_EXT)),true)

--- a/hal/audio_extn/Android.mk
+++ b/hal/audio_extn/Android.mk
@@ -650,7 +650,6 @@ LOCAL_SHARED_LIBRARIES := \
     libdl \
     libexpat \
     libhidlbase \
-    libhidltransport \
     liblog \
     libtinyalsa \
     libtinycompress \


### PR DESCRIPTION
In Android Q libhidltransport and libhwbinder were deprecated and all the symbols of those libraries were moved to libhidlbase.
Thus lets remove those libraries as they serve no purpose.

Commits that made those changes upstream:
https://android.googlesource.com/platform/system/libhidl/+/8f65ba713e73b40dc58dd7a8a702a96d6c1c2181
https://android.googlesource.com/platform/system/libhidl/+/a46371d5b3ffd08808ae93ec420721345738ec65
https://android.googlesource.com/platform/system/libhwbinder/+/09a8725d56b168668a11530537c9738f4bc58a90