### PR TITLE
[PRIMARY-HAL] [R] Drop unnecessary COPY_HEADERS 

### DIFF
--- a/hal/Android.mk
+++ b/hal/Android.mk
@@ -343,9 +343,6 @@ endif
 LOCAL_CFLAGS += -D_GNU_SOURCE
 LOCAL_CFLAGS += -Wall -Werror
 
-LOCAL_COPY_HEADERS_TO   := mm-audio
-LOCAL_COPY_HEADERS      := audio_extn/audio_defs.h
-
 ifeq ($(strip $(AUDIO_FEATURE_ENABLED_GCOV)),true)
     LOCAL_CFLAGS += --coverage -fprofile-arcs -ftest-coverage
     LOCAL_CPPFLAGS += --coverage -fprofile-arcs -ftest-coverage


### PR DESCRIPTION
`COPY_HEADERS` is rightfully and finally deprecated and dropped on R.
We have no external audio libraries needing the definitions for `audio_extn`; exporting this header is not necessary.