### PR TITLE
[audio/primary] [R] cirrus_sony: Update path in adition to resetting in stop_processing

### DIFF
--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -1456,8 +1456,8 @@ void spkr_prot_stop_processing(__unused snd_device_t snd_device) {
 
     ALOGV("%s: Entry", __func__);
 
-    audio_route_reset_path(adev->audio_route,
-                           fp_platform_get_snd_device_name(snd_device));
+    audio_route_reset_and_update_path(adev->audio_route,
+                                      fp_platform_get_snd_device_name(snd_device));
 
     pthread_mutex_lock(&handle.fb_prot_mutex);
 


### PR DESCRIPTION
Just resetting the path at hand does not seem to recursively reset included `<path>`s.

In the case of our dual mono feature `EAR_RDAC Switch` stays on when headphones are plugged in after playing back audio on speakers meaning that the sound is still coming from the earpiece.

With this change `EAR_RDAC Switch` is properly reset to `Off` when plugging in headphones and audio does not play over the earpiece anymore.

Fixes: 9c89b44a1fc747c8008d8be468d3ed214cf4c147
