### PR TITLE
[r-mr1] hal: define default HOSTLESS macros to invalid id

### DIFF
--- a/hal/msm8974/platform.h
+++ b/hal/msm8974/platform.h
@@ -636,6 +636,13 @@ enum {
 #define VOWLAN_CALL_PCM_DEVICE 36
 #endif
 
+#ifndef HOST_LESS_RX_ID
+#define HOST_LESS_RX_ID -1
+#endif
+#ifndef HOST_LESS_TX_ID
+#define HOST_LESS_TX_ID -1
+#endif
+
 #ifdef PLATFORM_MSM8996
 #define VOICEMMODE1_CALL_PCM_DEVICE 2
 #define VOICEMMODE2_CALL_PCM_DEVICE 22


### PR DESCRIPTION
This allows nile to at least build on [r-mr1] and have some sound (at least voice routing is not working but I've been able to listen to YouTube and music).