### PR TITLE
[r-mr1] hal: Disable TARGET_BOARD_AUTO

### DIFF
--- a/hal/Android.mk
+++ b/hal/Android.mk
@@ -117,10 +117,6 @@ ifneq ($(filter msm8953,$(TARGET_BOARD_PLATFORM)),)
 endif
 endif
 
-ifeq ($(TARGET_BOARD_AUTO),true)
-  LOCAL_CFLAGS += -DPLATFORM_AUTO
-endif
-
 LOCAL_CFLAGS += -Wno-macro-redefined
 
 LOCAL_HEADER_LIBRARIES := libhardware_headers

--- a/hal/audio_extn/Android.mk
+++ b/hal/audio_extn/Android.mk
@@ -536,10 +536,6 @@ ifneq ($(filter sdm845 sdm710 sdmshrike sm8150 kona lahaina holi lito bengal ato
   MULTIPLE_HW_VARIANTS_ENABLED := true
 endif
 
-ifeq ($(TARGET_BOARD_AUTO),true)
-  LOCAL_CFLAGS += -DPLATFORM_AUTO
-endif
-
 LOCAL_SRC_FILES:= \
         hfp.c \
         device_utils.c


### PR DESCRIPTION
There is no need nowadays to rely on AUTO platform features (as a
bonus we get audio call working on `nile`).

THIS SHOULD BE TESTED ON ALL PLATFORMS (I've tested locally on `pioneer/nile` and `pdx201/seine`).