### PR TITLE
[DNM] [AUDIO-HAL-PRIMARY]  [Q-MR1] audio_extn: cirrus_sony: Force CS35L41 wakeup during playback

### DIFF
--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -1434,6 +1434,8 @@ int spkr_prot_start_processing(__unused snd_device_t snd_device) {
 
     pthread_mutex_lock(&handle.fb_prot_mutex);
 
+    ret = cirrus_set_force_wake(true);
+
     audio_route_apply_and_update_path(adev->audio_route,
                                       fp_platform_get_snd_device_name(snd_device));
 
@@ -1464,6 +1466,8 @@ void spkr_prot_stop_processing(__unused snd_device_t snd_device) {
     handle.state = IDLE;
 
     pthread_mutex_unlock(&handle.fb_prot_mutex);
+
+    (void)cirrus_set_force_wake(false);
 
     ALOGV("%s: Exit", __func__);
 }


### PR DESCRIPTION
The CS35L41 codec may not be waking up on its own for firmware
issues. Since we know when we start playing back audio and when
we actually stop to, let's force it off of hibernation.

*******
I've learnt about issues with this codec and saw a kernel patch that
is actually disabling the hibernation for the entire CS35L41 hardware.
Leaving the DSP+AMP always on not only drains power, but may also
give thermal constraints issues, especially in a period of time in which
the device is hot for external influence (sun, high ambient temp, charging
while doing heavy processing and others) and may actually make havoc.

The proposed changes are just an idea that is untested.
Please test this commit with hibernation enabled in kernel.

Failing to fullfill the kernel enablement requirement invalidates the test.