### PR TITLE
[AUDIO] [9.12] cirrus_sony: Do not return -EINVAL when cirrus_save_calibration succeeds

### DIFF
--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -266,7 +266,7 @@ end:
 static int cirrus_save_calibration(struct cirrus_playback_session *hdl) {
     FILE* fp_calparams = NULL;
     struct cirrus_cal_file_t fdata;
-    int ret = -EINVAL;
+    int ret = 0;
 
     fp_calparams = fopen(CIRRUS_AUDIO_CAL_PATH, "wb");
     if (fp_calparams == NULL)


### PR DESCRIPTION
Initializing ret to -EINVAL, but never updating it when everything is sucessful results in a misleading:

    audio_hw_sony_cirrus_playback: cirrus_do_calibration: Cannot save calibration to file (-22)!!!
