### PR TITLE
[q-mr1] [AUDIO] cirrus_sony: Calibration fix for mono calibration

### DIFF
--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -44,8 +44,6 @@ static fp_enable_disable_snd_device_t fp_disable_snd_device;
 static fp_enable_disable_snd_device_t  fp_enable_snd_device;
 static fp_enable_disable_audio_route_t fp_disable_audio_route;
 static fp_enable_disable_audio_route_t fp_enable_audio_route;
-static fp_audio_extn_get_snd_card_split_t fp_audio_extn_get_snd_card_split;
-static fp_platform_get_snd_device_t fp_platform_get_vi_feedback_snd_device;
 
 enum cirrus_playback_state {
     INIT = 0,
@@ -385,9 +383,6 @@ void spkr_prot_init(void *adev, spkr_prot_init_config_t spkr_prot_init_config_va
     fp_enable_snd_device = spkr_prot_init_config_val.fp_enable_snd_device;
     fp_disable_audio_route = spkr_prot_init_config_val.fp_disable_audio_route;
     fp_enable_audio_route = spkr_prot_init_config_val.fp_enable_audio_route;
-    fp_audio_extn_get_snd_card_split = spkr_prot_init_config_val.fp_audio_extn_get_snd_card_split;
-    fp_platform_get_vi_feedback_snd_device = spkr_prot_init_config_val.fp_platform_get_vi_feedback_snd_device;
-
 
     pthread_mutex_init(&handle.fb_prot_mutex, NULL);
 

--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -610,6 +610,13 @@ static int cirrus_play_silence(int seconds) {
     if (!uc_info_rx) {
         return -ENOMEM;
     }
+
+    while (!adev->primary_output) {
+        ALOGE("Still no primary_output!");
+        // TODO: Perhaps wait on a condvar like spkr_prot?
+        usleep(1000);
+    }
+
     uc_info_rx->id = USECASE_AUDIO_PLAYBACK_DEEP_BUFFER;
     uc_info_rx->type = PCM_PLAYBACK;
     uc_info_rx->in_snd_device = SND_DEVICE_NONE;

--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -266,7 +266,7 @@ end:
 static int cirrus_save_calibration(struct cirrus_playback_session *hdl) {
     FILE* fp_calparams = NULL;
     struct cirrus_cal_file_t fdata;
-    int ret = -EINVAL;
+    int ret = 0;
 
     fp_calparams = fopen(CIRRUS_AUDIO_CAL_PATH, "wb");
     if (fp_calparams == NULL)

--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -413,12 +413,12 @@ int spkr_prot_deinit() {
 }
 
 static int cirrus_format_mixer_name(const char* name, const char* channel,
-                                    char **buf_out, int buf_sz)
+                                    char *buf_out, int buf_sz)
 {
     if (name == NULL)
         return -EINVAL;
 
-    memset(*buf_out, 0, buf_sz);
+    memset(buf_out, 0, buf_sz);
 
     /*
      * If we have two amps, then we have L and R controls, otherwise
@@ -432,9 +432,9 @@ static int cirrus_format_mixer_name(const char* name, const char* channel,
      * 0 for MONO, L or R for STEREO L/R.
      */
     if (channel == NULL || channel[0] < 'L')
-        return snprintf(*buf_out, buf_sz, "%s", name);
+        return snprintf(buf_out, buf_sz, "%s", name);
 
-    return snprintf(*buf_out, buf_sz, "%s %s", channel, name);
+    return snprintf(buf_out, buf_sz, "%s %s", channel, name);
 }
 
 /* TODO: This function assumes that we are always using CARD 0 */
@@ -472,15 +472,15 @@ static int cirrus_set_mixer_value_by_name_lr(char* ctl_base_name, int value) {
 
     ctl_name = (char *)calloc(ctl_sz, sizeof(char));
 
-    ret = cirrus_format_mixer_name(ctl_base_name, "L", &ctl_name, ctl_sz);
-    ret += cirrus_set_mixer_value_by_name(ctl_name, 1);
+    ret = cirrus_format_mixer_name(ctl_base_name, "L", ctl_name, ctl_sz);
+    ret += cirrus_set_mixer_value_by_name(ctl_name, value);
     if (ret < 0) {
         ALOGE("%s: Cannot set mixer %s to %d", __func__, ctl_name, value);
         goto end;
     }
 
-    ret = cirrus_format_mixer_name(ctl_base_name, "R", &ctl_name, ctl_sz);
-    ret += cirrus_set_mixer_value_by_name(ctl_name, 1);
+    ret = cirrus_format_mixer_name(ctl_base_name, "R", ctl_name, ctl_sz);
+    ret += cirrus_set_mixer_value_by_name(ctl_name, value);
     if (ret < 0)
         ALOGE("%s: Cannot set mixer %s to %d", __func__, ctl_name, value);
 end:
@@ -696,7 +696,7 @@ static int cirrus_do_reset(const char *channel) {
     int ret = 0;
 
     ctl_name = (char *)calloc(ctl_sz, sizeof(char));
-    ret = cirrus_format_mixer_name("CCM Reset", channel, &ctl_name, ctl_sz);
+    ret = cirrus_format_mixer_name("CCM Reset", channel, ctl_name, ctl_sz);
     ret += cirrus_get_mixer_value_by_name(ctl_name);
     if (ret < 0) {
         ALOGE("%s: CCM Reset is missing!!!", __func__);
@@ -725,7 +725,7 @@ static int cirrus_exec_fw_download(const char *fw_type, const char *channel,
     ctl_name = (char *)calloc(ctl_sz, sizeof(char));
 
     /* If this one is missing, we're not using our Cirrus codec... */
-    ret = cirrus_format_mixer_name("DSP Booted", channel, &ctl_name, ctl_sz);
+    ret = cirrus_format_mixer_name("DSP Booted", channel, ctl_name, ctl_sz);
     ret += cirrus_get_mixer_value_by_name(ctl_name);
     if (ret < 0) {
         ALOGE("%s: %s control is missing. Bailing out.", __func__, ctl_name);
@@ -743,7 +743,7 @@ static int cirrus_exec_fw_download(const char *fw_type, const char *channel,
     usleep(5000);
 
     ret = cirrus_format_mixer_name("DSP1 Preload Switch",
-                                   channel, &ctl_name, ctl_sz);
+                                   channel, ctl_name, ctl_sz);
     ret += cirrus_set_mixer_value_by_name(ctl_name, 0);
     if (ret < 0) {
         ALOGE("%s: Cannot reset %s", __func__, ctl_name);
@@ -752,14 +752,14 @@ static int cirrus_exec_fw_download(const char *fw_type, const char *channel,
     usleep(5000);
 
     /* Determine what firmware to load and configure DSP */
-    ret = cirrus_format_mixer_name("DSP1 Firmware", channel, &ctl_name, ctl_sz);
+    ret = cirrus_format_mixer_name("DSP1 Firmware", channel, ctl_name, ctl_sz);
     ret += cirrus_set_mixer_enum_by_name(ctl_name, fw_type);
     if (ret < 0) {
         ALOGE("%s: Cannot set %s to %s", __func__, ctl_name, fw_type);
         goto exit;
     }
 
-    ret = cirrus_format_mixer_name("PCM Source", channel, &ctl_name, ctl_sz);
+    ret = cirrus_format_mixer_name("PCM Source", channel, ctl_name, ctl_sz);
     ret += cirrus_set_mixer_enum_by_name(ctl_name, "DSP");
     if (ret < 0) {
         ALOGE("%s: Cannot set %s to DSP", __func__, ctl_name);
@@ -768,7 +768,7 @@ static int cirrus_exec_fw_download(const char *fw_type, const char *channel,
 
     /* Send the firmware! */
     ret = cirrus_format_mixer_name("DSP1 Preload Switch",
-                                   channel, &ctl_name, ctl_sz);
+                                   channel, ctl_name, ctl_sz);
     ret += cirrus_set_mixer_value_by_name(ctl_name, 1);
     if (ret < 0) {
         ALOGE("%s: Cannot set %s to %s", __func__, ctl_name, fw_type);
@@ -777,10 +777,10 @@ static int cirrus_exec_fw_download(const char *fw_type, const char *channel,
 
     if (!strcmp(fw_type, "Protection")) {
         ret = cirrus_format_mixer_name("DSP1 Protection cd CSPL_ENABLE",
-                                       channel, &ctl_name, ctl_sz);
+                                       channel, ctl_name, ctl_sz);
     } else if (!strcmp(fw_type, "Calibration")) {
         ret = cirrus_format_mixer_name("DSP1 Calibration cd CSPL_ENABLE",
-                                       channel, &ctl_name, ctl_sz);
+                                       channel, ctl_name, ctl_sz);
     } else {
         ret = -EINVAL;
         ALOGE("%s: ERROR! Unsupported firmware type passed: %s",
@@ -981,7 +981,7 @@ static int cirrus_stereo_calibration(void) {
               __func__);
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_CALI_CAL_STATUS, "L",
-                                   &ctl_name, ctl_sz);
+                                   ctl_name, ctl_sz);
     ret += cirrus_get_mixer_array_by_name(ctl_name,
                                           &handle.spkl.status, 4);
     if (ret < 0) {
@@ -990,7 +990,7 @@ static int cirrus_stereo_calibration(void) {
     }
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_CALI_CAL_STATUS, "R",
-                                   &ctl_name, ctl_sz);
+                                   ctl_name, ctl_sz);
     ret += cirrus_get_mixer_array_by_name(ctl_name,
                                           &handle.spkr.status, 4);
     if (ret < 0) {
@@ -1023,7 +1023,7 @@ static int cirrus_stereo_calibration(void) {
     }
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_CALI_CAL_CHECKSUM, "L",
-                                   &ctl_name, ctl_sz);
+                                   ctl_name, ctl_sz);
     ret += cirrus_get_mixer_array_by_name(ctl_name,
                                          &handle.spkl.checksum, 4);
     if (ret < 0) {
@@ -1032,7 +1032,7 @@ static int cirrus_stereo_calibration(void) {
     }
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_CALI_CAL_CHECKSUM, "R",
-                                   &ctl_name, ctl_sz);
+                                   ctl_name, ctl_sz);
     ret += cirrus_get_mixer_array_by_name(ctl_name,
                                          &handle.spkr.checksum, 4);
     if (ret < 0) {
@@ -1041,7 +1041,7 @@ static int cirrus_stereo_calibration(void) {
     }
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_CALI_CAL_R, "L",
-                                   &ctl_name, ctl_sz);
+                                   ctl_name, ctl_sz);
     ret += cirrus_get_mixer_array_by_name(ctl_name,
                                          &handle.spkl.cal_r, 4);
     if (ret < 0) {
@@ -1050,7 +1050,7 @@ static int cirrus_stereo_calibration(void) {
     }
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_CALI_CAL_R, "R",
-                                   &ctl_name, ctl_sz);
+                                   ctl_name, ctl_sz);
     ret += cirrus_get_mixer_array_by_name(ctl_name,
                                          &handle.spkr.cal_r, 4);
     if (ret < 0) {
@@ -1157,7 +1157,7 @@ static int cirrus_do_fw_stereo_download(int do_reset) {
         goto exit;
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_R, "L",
-                                    &ctl_name, ctl_sz);
+                                    ctl_name, ctl_sz);
     ret += cirrus_set_mixer_array_by_name(ctl_name,
                                          &handle.spkl.cal_r, 4);
     if (ret < 0) {
@@ -1166,7 +1166,7 @@ static int cirrus_do_fw_stereo_download(int do_reset) {
     }
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_R, "R",
-                                    &ctl_name, ctl_sz);
+                                    ctl_name, ctl_sz);
     ret += cirrus_set_mixer_array_by_name(ctl_name,
                                          &handle.spkr.cal_r, 4);
     if (ret < 0) {
@@ -1175,7 +1175,7 @@ static int cirrus_do_fw_stereo_download(int do_reset) {
     }
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_STATUS, "L",
-                                    &ctl_name, ctl_sz);
+                                    ctl_name, ctl_sz);
     ret += cirrus_set_mixer_array_by_name(ctl_name,
                                          &handle.spkl.status, 4);
     if (ret < 0) {
@@ -1184,7 +1184,7 @@ static int cirrus_do_fw_stereo_download(int do_reset) {
     }
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_STATUS, "R",
-                                    &ctl_name, ctl_sz);
+                                    ctl_name, ctl_sz);
     ret += cirrus_set_mixer_array_by_name(ctl_name,
                                          &handle.spkr.status, 4);
     if (ret < 0) {
@@ -1193,7 +1193,7 @@ static int cirrus_do_fw_stereo_download(int do_reset) {
     }
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_CHECKSUM, "L",
-                                    &ctl_name, ctl_sz);
+                                    ctl_name, ctl_sz);
     ret += cirrus_set_mixer_array_by_name(ctl_name,
                                          &handle.spkl.checksum, 4);
     if (ret < 0) {
@@ -1202,7 +1202,7 @@ static int cirrus_do_fw_stereo_download(int do_reset) {
     }
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_CHECKSUM, "R",
-                                    &ctl_name, ctl_sz);
+                                    ctl_name, ctl_sz);
     ret += cirrus_set_mixer_array_by_name(ctl_name,
                                          &handle.spkr.checksum, 4);
     if (ret < 0) {
@@ -1318,7 +1318,7 @@ static int cirrus_check_error_state_stereo(void) {
 
     ctl_name = (char *)calloc(ctl_sz, sizeof(char));
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CSPL_ERRORNO, "L",
-                                   &ctl_name, ctl_sz);
+                                   ctl_name, ctl_sz);
     ret += cirrus_get_mixer_array_by_name(ctl_name, &cspl_error, 4);
     if (ret < 0) {
         ALOGE("%s: Cannot get %s", __func__, ctl_name);
@@ -1332,7 +1332,7 @@ static int cirrus_check_error_state_stereo(void) {
     }
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CSPL_ERRORNO, "R",
-                                   &ctl_name, ctl_sz);
+                                   ctl_name, ctl_sz);
     ret += cirrus_get_mixer_array_by_name(ctl_name, &cspl_error, 4);
     if (ret < 0) {
         ALOGE("%s: Cannot get %s", __func__, ctl_name);

--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -671,20 +671,11 @@ exit:
 }
 
 static inline int cirrus_set_force_wake(bool enable) {
-    char *ctl_name;
-    int ctl_sz = CIRRUS_CTL_NAME_BUF;
     int ret = 0;
 
     if (handle.is_stereo) {
-        ctl_name = (char *)calloc(ctl_sz, sizeof(char));
-        ret = cirrus_format_mixer_name(CIRRUS_CTL_FORCE_WAKE, "L",
-                                        &ctl_name, ctl_sz);
-        ret += cirrus_set_mixer_value_by_name(ctl_name, (int)enable);
-
-        ret += cirrus_format_mixer_name(CIRRUS_CTL_FORCE_WAKE, "R",
-                                        &ctl_name, ctl_sz);
-        ret += cirrus_set_mixer_value_by_name(ctl_name, (int)enable);
-        free(ctl_name);
+        ret = cirrus_set_mixer_value_by_name_lr(CIRRUS_CTL_FORCE_WAKE,
+                                                (int)enable);
     } else {
         ret = cirrus_set_mixer_value_by_name(CIRRUS_CTL_FORCE_WAKE,
                                              (int)enable);
@@ -976,14 +967,8 @@ static int cirrus_stereo_calibration(void) {
         goto exit;
 
     /* Same CAL_AMBIENT for both speakers */
-    ret = cirrus_format_mixer_name(CIRRUS_CTL_CALI_CAL_AMBIENT, "L",
-                                   &ctl_name, ctl_sz);
-    ret += cirrus_set_mixer_array_by_name(CIRRUS_CTL_CALI_CAL_AMBIENT,
-                                          cal_ambient, 4);
-    ret += cirrus_format_mixer_name(CIRRUS_CTL_CALI_CAL_AMBIENT, "R",
-                                   &ctl_name, ctl_sz);
-    ret += cirrus_set_mixer_array_by_name(CIRRUS_CTL_CALI_CAL_AMBIENT,
-                                          cal_ambient, 4);
+    ret = cirrus_set_mixer_value_by_name_lr(CIRRUS_CTL_CALI_CAL_AMBIENT,
+                                            4);
     if (ret < 0) {
         ALOGE("%s: Cannot set ambient calibration", __func__);
         goto exit;

--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -466,25 +466,21 @@ exit:
 }
 
 static int cirrus_set_mixer_value_by_name_lr(char* ctl_base_name, int value) {
-    char *ctl_name;
-    int ctl_sz = CIRRUS_CTL_NAME_BUF;
+    char ctl_name[CIRRUS_CTL_NAME_BUF];
     int ret = 0;
 
-    ctl_name = (char *)calloc(ctl_sz, sizeof(char));
-
-    ret = cirrus_format_mixer_name(ctl_base_name, "L", ctl_name, ctl_sz);
+    ret = cirrus_format_mixer_name(ctl_base_name, "L", ctl_name, sizeof(ctl_name));
     ret += cirrus_set_mixer_value_by_name(ctl_name, value);
     if (ret < 0) {
         ALOGE("%s: Cannot set mixer %s to %d", __func__, ctl_name, value);
         goto end;
     }
 
-    ret = cirrus_format_mixer_name(ctl_base_name, "R", ctl_name, ctl_sz);
+    ret = cirrus_format_mixer_name(ctl_base_name, "R", ctl_name, sizeof(ctl_name));
     ret += cirrus_set_mixer_value_by_name(ctl_name, value);
     if (ret < 0)
         ALOGE("%s: Cannot set mixer %s to %d", __func__, ctl_name, value);
 end:
-    free(ctl_name);
     return ret;
 }
 
@@ -691,12 +687,10 @@ static inline int cirrus_set_force_wake(bool enable) {
 }
 
 static int cirrus_do_reset(const char *channel) {
-    char *ctl_name;
-    int ctl_sz = CIRRUS_CTL_NAME_BUF;
+    char ctl_name[CIRRUS_CTL_NAME_BUF];
     int ret = 0;
 
-    ctl_name = (char *)calloc(ctl_sz, sizeof(char));
-    ret = cirrus_format_mixer_name("CCM Reset", channel, ctl_name, ctl_sz);
+    ret = cirrus_format_mixer_name("CCM Reset", channel, ctl_name, sizeof(ctl_name));
     ret += cirrus_get_mixer_value_by_name(ctl_name);
     if (ret < 0) {
         ALOGE("%s: CCM Reset is missing!!!", __func__);
@@ -705,14 +699,12 @@ static int cirrus_do_reset(const char *channel) {
         ALOGI("%s: CCM Reset done.", __func__);
     }
 
-    free(ctl_name);
     return ret;
 }
 
 static int cirrus_exec_fw_download(const char *fw_type, const char *channel,
                                    int do_reset) {
-    char *ctl_name;
-    int ctl_sz = CIRRUS_CTL_NAME_BUF;
+    char ctl_name[CIRRUS_CTL_NAME_BUF];
     uint8_t cspl_ena[4] = { 0 };
     int retry = 0, ret;
 
@@ -722,10 +714,8 @@ static int cirrus_exec_fw_download(const char *fw_type, const char *channel,
     if (do_reset)
         ret = cirrus_do_reset(channel);
 
-    ctl_name = (char *)calloc(ctl_sz, sizeof(char));
-
     /* If this one is missing, we're not using our Cirrus codec... */
-    ret = cirrus_format_mixer_name("DSP Booted", channel, ctl_name, ctl_sz);
+    ret = cirrus_format_mixer_name("DSP Booted", channel, ctl_name, sizeof(ctl_name));
     ret += cirrus_get_mixer_value_by_name(ctl_name);
     if (ret < 0) {
         ALOGE("%s: %s control is missing. Bailing out.", __func__, ctl_name);
@@ -743,7 +733,7 @@ static int cirrus_exec_fw_download(const char *fw_type, const char *channel,
     usleep(5000);
 
     ret = cirrus_format_mixer_name("DSP1 Preload Switch",
-                                   channel, ctl_name, ctl_sz);
+                                   channel, ctl_name, sizeof(ctl_name));
     ret += cirrus_set_mixer_value_by_name(ctl_name, 0);
     if (ret < 0) {
         ALOGE("%s: Cannot reset %s", __func__, ctl_name);
@@ -752,14 +742,14 @@ static int cirrus_exec_fw_download(const char *fw_type, const char *channel,
     usleep(5000);
 
     /* Determine what firmware to load and configure DSP */
-    ret = cirrus_format_mixer_name("DSP1 Firmware", channel, ctl_name, ctl_sz);
+    ret = cirrus_format_mixer_name("DSP1 Firmware", channel, ctl_name, sizeof(ctl_name));
     ret += cirrus_set_mixer_enum_by_name(ctl_name, fw_type);
     if (ret < 0) {
         ALOGE("%s: Cannot set %s to %s", __func__, ctl_name, fw_type);
         goto exit;
     }
 
-    ret = cirrus_format_mixer_name("PCM Source", channel, ctl_name, ctl_sz);
+    ret = cirrus_format_mixer_name("PCM Source", channel, ctl_name, sizeof(ctl_name));
     ret += cirrus_set_mixer_enum_by_name(ctl_name, "DSP");
     if (ret < 0) {
         ALOGE("%s: Cannot set %s to DSP", __func__, ctl_name);
@@ -768,7 +758,7 @@ static int cirrus_exec_fw_download(const char *fw_type, const char *channel,
 
     /* Send the firmware! */
     ret = cirrus_format_mixer_name("DSP1 Preload Switch",
-                                   channel, ctl_name, ctl_sz);
+                                   channel, ctl_name, sizeof(ctl_name));
     ret += cirrus_set_mixer_value_by_name(ctl_name, 1);
     if (ret < 0) {
         ALOGE("%s: Cannot set %s to %s", __func__, ctl_name, fw_type);
@@ -777,10 +767,10 @@ static int cirrus_exec_fw_download(const char *fw_type, const char *channel,
 
     if (!strcmp(fw_type, "Protection")) {
         ret = cirrus_format_mixer_name("DSP1 Protection cd CSPL_ENABLE",
-                                       channel, ctl_name, ctl_sz);
+                                       channel, ctl_name, sizeof(ctl_name));
     } else if (!strcmp(fw_type, "Calibration")) {
         ret = cirrus_format_mixer_name("DSP1 Calibration cd CSPL_ENABLE",
-                                       channel, ctl_name, ctl_sz);
+                                       channel, ctl_name, sizeof(ctl_name));
     } else {
         ret = -EINVAL;
         ALOGE("%s: ERROR! Unsupported firmware type passed: %s",
@@ -827,8 +817,6 @@ retry_fw:
     }
 
 exit:
-    free(ctl_name);
-
     usleep(10000);
     return ret;
 }
@@ -955,12 +943,9 @@ exit:
 /* TODO: Implement diagnostics for stereo -- left because too messy now */
 static int cirrus_stereo_calibration(void) {
     struct audio_device *adev = handle.adev_handle;
-    char *ctl_name;
-    int ctl_sz = CIRRUS_CTL_NAME_BUF;
+    char ctl_name[CIRRUS_CTL_NAME_BUF];
     bool stat_l_nok = true, stat_r_nok = true;
     int ret = 0;
-
-    ctl_name = (char *)calloc(ctl_sz, sizeof(char));
 
     ret = cirrus_set_force_wake(true);
     if (ret < 0)
@@ -981,7 +966,7 @@ static int cirrus_stereo_calibration(void) {
               __func__);
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_CALI_CAL_STATUS, "L",
-                                   ctl_name, ctl_sz);
+                                   ctl_name, sizeof(ctl_name));
     ret += cirrus_get_mixer_array_by_name(ctl_name,
                                           &handle.spkl.status, 4);
     if (ret < 0) {
@@ -990,7 +975,7 @@ static int cirrus_stereo_calibration(void) {
     }
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_CALI_CAL_STATUS, "R",
-                                   ctl_name, ctl_sz);
+                                   ctl_name, sizeof(ctl_name));
     ret += cirrus_get_mixer_array_by_name(ctl_name,
                                           &handle.spkr.status, 4);
     if (ret < 0) {
@@ -1023,7 +1008,7 @@ static int cirrus_stereo_calibration(void) {
     }
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_CALI_CAL_CHECKSUM, "L",
-                                   ctl_name, ctl_sz);
+                                   ctl_name, sizeof(ctl_name));
     ret += cirrus_get_mixer_array_by_name(ctl_name,
                                          &handle.spkl.checksum, 4);
     if (ret < 0) {
@@ -1032,7 +1017,7 @@ static int cirrus_stereo_calibration(void) {
     }
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_CALI_CAL_CHECKSUM, "R",
-                                   ctl_name, ctl_sz);
+                                   ctl_name, sizeof(ctl_name));
     ret += cirrus_get_mixer_array_by_name(ctl_name,
                                          &handle.spkr.checksum, 4);
     if (ret < 0) {
@@ -1041,7 +1026,7 @@ static int cirrus_stereo_calibration(void) {
     }
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_CALI_CAL_R, "L",
-                                   ctl_name, ctl_sz);
+                                   ctl_name, sizeof(ctl_name));
     ret += cirrus_get_mixer_array_by_name(ctl_name,
                                          &handle.spkl.cal_r, 4);
     if (ret < 0) {
@@ -1050,7 +1035,7 @@ static int cirrus_stereo_calibration(void) {
     }
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_CALI_CAL_R, "R",
-                                   ctl_name, ctl_sz);
+                                   ctl_name, sizeof(ctl_name));
     ret += cirrus_get_mixer_array_by_name(ctl_name,
                                          &handle.spkr.cal_r, 4);
     if (ret < 0) {
@@ -1067,7 +1052,6 @@ static int cirrus_stereo_calibration(void) {
     handle.spkr.cal_ok = true;
 
 exit:
-    free(ctl_name);
     return ret;
 }
 
@@ -1122,19 +1106,16 @@ exit:
 }
 
 static int cirrus_do_fw_stereo_download(int do_reset) {
-    char *ctl_name;
-    int ctl_sz = CIRRUS_CTL_NAME_BUF;
+    char ctl_name[CIRRUS_CTL_NAME_BUF];
     bool cal_valid = false, status_ok = false, checksum_ok = false;
     int ret = 0;
 
     ALOGI("%s: Sending speaker protection stereo firmware", __func__);
 
-    ctl_name = (char *)calloc(ctl_sz, sizeof(char));
     ret = cirrus_exec_fw_download("Protection", "L", do_reset);
     if (ret != 0) {
         ALOGE("%s: Cannot send Protection L firmware: bailing out.",
               __func__);
-        free(ctl_name);
         return -EINVAL;
     }
 
@@ -1142,13 +1123,11 @@ static int cirrus_do_fw_stereo_download(int do_reset) {
     if (ret != 0) {
         ALOGE("%s: Cannot send Protection R firmware: bailing out.",
               __func__);
-        free(ctl_name);
         return -EINVAL;
     }
 
     /* If the calibration is not valid, keep the fw loaded but get out. */
     if (!handle.spkl.cal_ok || !handle.spkr.cal_ok) {
-        free(ctl_name);
         return -EINVAL;
     }
 
@@ -1157,7 +1136,7 @@ static int cirrus_do_fw_stereo_download(int do_reset) {
         goto exit;
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_R, "L",
-                                    ctl_name, ctl_sz);
+                                    ctl_name, sizeof(ctl_name));
     ret += cirrus_set_mixer_array_by_name(ctl_name,
                                          &handle.spkl.cal_r, 4);
     if (ret < 0) {
@@ -1166,7 +1145,7 @@ static int cirrus_do_fw_stereo_download(int do_reset) {
     }
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_R, "R",
-                                    ctl_name, ctl_sz);
+                                    ctl_name, sizeof(ctl_name));
     ret += cirrus_set_mixer_array_by_name(ctl_name,
                                          &handle.spkr.cal_r, 4);
     if (ret < 0) {
@@ -1175,7 +1154,7 @@ static int cirrus_do_fw_stereo_download(int do_reset) {
     }
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_STATUS, "L",
-                                    ctl_name, ctl_sz);
+                                    ctl_name, sizeof(ctl_name));
     ret += cirrus_set_mixer_array_by_name(ctl_name,
                                          &handle.spkl.status, 4);
     if (ret < 0) {
@@ -1184,7 +1163,7 @@ static int cirrus_do_fw_stereo_download(int do_reset) {
     }
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_STATUS, "R",
-                                    ctl_name, ctl_sz);
+                                    ctl_name, sizeof(ctl_name));
     ret += cirrus_set_mixer_array_by_name(ctl_name,
                                          &handle.spkr.status, 4);
     if (ret < 0) {
@@ -1193,7 +1172,7 @@ static int cirrus_do_fw_stereo_download(int do_reset) {
     }
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_CHECKSUM, "L",
-                                    ctl_name, ctl_sz);
+                                    ctl_name, sizeof(ctl_name));
     ret += cirrus_set_mixer_array_by_name(ctl_name,
                                          &handle.spkl.checksum, 4);
     if (ret < 0) {
@@ -1202,7 +1181,7 @@ static int cirrus_do_fw_stereo_download(int do_reset) {
     }
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_CHECKSUM, "R",
-                                    ctl_name, ctl_sz);
+                                    ctl_name, sizeof(ctl_name));
     ret += cirrus_set_mixer_array_by_name(ctl_name,
                                          &handle.spkr.checksum, 4);
     if (ret < 0) {
@@ -1216,7 +1195,6 @@ static int cirrus_do_fw_stereo_download(int do_reset) {
         goto exit;
 
 exit:
-    free(ctl_name);
     ret += cirrus_play_silence(0);
     return ret;
 }
@@ -1307,8 +1285,7 @@ exit:
 }
 
 static int cirrus_check_error_state_stereo(void) {
-    char *ctl_name;
-    int ctl_sz = CIRRUS_CTL_NAME_BUF;
+    char ctl_name[CIRRUS_CTL_NAME_BUF];
     uint8_t cspl_error[4] = { 0 };
     int ret = 0;
 
@@ -1316,9 +1293,8 @@ static int cirrus_check_error_state_stereo(void) {
     if (ret < 0)
         return ret;
 
-    ctl_name = (char *)calloc(ctl_sz, sizeof(char));
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CSPL_ERRORNO, "L",
-                                   ctl_name, ctl_sz);
+                                   ctl_name, sizeof(ctl_name));
     ret += cirrus_get_mixer_array_by_name(ctl_name, &cspl_error, 4);
     if (ret < 0) {
         ALOGE("%s: Cannot get %s", __func__, ctl_name);
@@ -1332,7 +1308,7 @@ static int cirrus_check_error_state_stereo(void) {
     }
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CSPL_ERRORNO, "R",
-                                   ctl_name, ctl_sz);
+                                   ctl_name, sizeof(ctl_name));
     ret += cirrus_get_mixer_array_by_name(ctl_name, &cspl_error, 4);
     if (ret < 0) {
         ALOGE("%s: Cannot get %s", __func__, ctl_name);
@@ -1346,7 +1322,6 @@ static int cirrus_check_error_state_stereo(void) {
     }
 
 exit:
-    free(ctl_name);
     ret = cirrus_set_force_wake(false);
     return ret;
 }

--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -114,9 +114,6 @@ int (*miscta_write_unit)(uint32_t id, const void *buf, uint32_t size) = NULL;
 #define TA_CIRRUS_CAL_SPKR_DIAG_Z_LOW_DIFF	4713
 #define TA_CIRRUS_CAL_SPKR_DIAG_F0_STATUS	4714
 
-/* Playback */
-#define CIRRUS_PLAYBACK_MIXER	"PRI_MI2S_RX Audio Mixer MultiMedia1"
-
 /* Mixer controls */
 #define CIRRUS_CTL_FORCE_WAKE		"Hibernate Force Wake"
 
@@ -597,15 +594,13 @@ static int cirrus_play_silence(int seconds) {
     struct pcm_config rx_tmp = { 0 };
 
     uint8_t *silence = NULL;
-    int i, ret, silence_bytes, silence_cnt = 1;
+    int i, ret = 0, silence_bytes, silence_cnt = 1;
     unsigned int buffer_size = 0, frames_bytes = 0;
+    int pcm_dev_rx_id = fp_platform_get_pcm_device_id(USECASE_AUDIO_PLAYBACK_DEEP_BUFFER, PCM_PLAYBACK);
 
+    audio_route_apply_and_update_path(adev->audio_route, "deep-buffer-playback");
 
-    ret = cirrus_set_mixer_value_by_name(CIRRUS_PLAYBACK_MIXER, 1);
-    if (ret)
-        return ret;
-
-    handle.pcm_rx = pcm_open(adev->snd_card, 0,
+    handle.pcm_rx = pcm_open(adev->snd_card, pcm_dev_rx_id,
                              PCM_OUT, &pcm_config_cirrus_rx);
     if (!handle.pcm_rx) {
         ALOGE("%s: Cannot open output PCM", __func__);
@@ -653,9 +648,7 @@ static int cirrus_play_silence(int seconds) {
     free(silence);
 
 exit:
-    ret = cirrus_set_mixer_value_by_name(CIRRUS_PLAYBACK_MIXER, 0);
-    if (ret)
-        return ret;
+    audio_route_reset_and_update_path(adev->audio_route, "deep-buffer-playback");
 
     pcm_close(handle.pcm_rx);
     return ret;

--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -1261,18 +1261,38 @@ exit:
 static int cirrus_do_fw_stereo_download(int do_reset) {
     char ctl_name[CIRRUS_CTL_NAME_BUF];
     bool cal_valid = false, status_ok = false, checksum_ok = false;
-    int ret = 0;
+    int i, max_retries = 24, ret = 0;
 
     ALOGI("%s: Sending speaker protection stereo firmware", __func__);
 
-    ret = cirrus_exec_fw_download("Protection", "R", do_reset);
+    for (i = 0; i < max_retries; i++) {
+        ret = cirrus_exec_fw_download("Protection", "R", do_reset);
+        if (ret == 0)
+            break;
+        usleep(500000);
+    }
     if (ret != 0) {
         ALOGE("%s: Cannot send Protection R firmware: bailing out.",
               __func__);
         return -EINVAL;
     }
 
-    ret = cirrus_exec_fw_download("Protection", "L", do_reset);
+    /*
+     * Guarantee that we retry for at least 3 seconds... but the
+     * other firmware should just load instantly, since we've been
+     * waiting for the DSP at R-SPK loading time.
+     *
+     * This is only to paranoidly account any possible future issue.
+     */
+    if (max_retries < 6)
+        max_retries = 6;
+
+    for (i = 0; i < max_retries; i++) {
+        ret = cirrus_exec_fw_download("Protection", "L", do_reset);
+        if (ret == 0)
+            break;
+        usleep(500000);
+    }
     if (ret != 0) {
         ALOGE("%s: Cannot send Protection L firmware: bailing out.",
               __func__);

--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -825,10 +825,10 @@ retry_fw:
         ret = 0;
     } else {
         /*
-	 * Since we are using a poor hack to load the firmware, we cannot know
+         * Since we are using a poor hack to load the firmware, we cannot know
          * if the firmware was found nor if it finished loading remotely.
-	 * We also don't know how much time does the chip require to actually
-	 * boot it, so we will sleep and retry for X times, until it loads and
+         * We also don't know how much time does the chip require to actually
+         * boot it, so we will sleep and retry for X times, until it loads and
          * boots, or we assume that something went wrong: in that case the
          * only thing left to do is to return an error, hoping that developers
          * will catch it before going crazy...

--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -132,7 +132,9 @@ int (*miscta_write_unit)(uint32_t id, const void *buf, uint32_t size) = NULL;
 #define CIRRUS_CTL_PROT_DIAG_Z_LOW_DIFF	"DSP1 Protection cd DIAG_Z_LOW_DIFF"
 #define CIRRUS_CTL_PROT_CAL_R		"DSP1 Protection cd CAL_R"
 #define CIRRUS_CTL_PROT_CAL_STATUS	"DSP1 Protection CAL_STATUS"
+#define CIRRUS_CTL_PROT_CAL_STATUS_CD	"DSP1 Protection cd CAL_STATUS"
 #define CIRRUS_CTL_PROT_CAL_CHECKSUM	"DSP1 Protection CAL_CHECKSUM"
+#define CIRRUS_CTL_PROT_CAL_CHECKSUM_CD	"DSP1 Protection cd CAL_CHECKSUM"
 
 #define CIRRUS_CTL_PROT_CSPL_ERRORNO	"DSP1 Protection cd CSPL_ERRORNO"
 
@@ -445,7 +447,7 @@ static int cirrus_set_mixer_value_by_name(char* ctl_name, int value) {
 
     ctl_config = mixer_get_ctl_by_name(card_mixer, ctl_name);
     if (!ctl_config) {
-        ALOGE("%s: Cannot get mixer control %s", __func__, ctl_name);
+        ALOGD("%s: Cannot get mixer control %s", __func__, ctl_name);
         ret = -1;
         goto exit;
     }
@@ -767,8 +769,7 @@ static int cirrus_exec_fw_download(const char *fw_type, const char *channel,
         ALOGE("%s: Cannot reset %s status", __func__, ctl_name);
         goto exit;
     }
-
-    usleep(5000);
+    usleep(10000);
 
     ret = cirrus_format_mixer_name("DSP1 Preload Switch",
                                    channel, ctl_name, sizeof(ctl_name));
@@ -779,7 +780,7 @@ static int cirrus_exec_fw_download(const char *fw_type, const char *channel,
         ALOGE("%s: Cannot reset %s", __func__, ctl_name);
         goto exit;
     }
-    usleep(5000);
+    usleep(10000);
 
     /* Determine what firmware to load and configure DSP */
     ret = cirrus_format_mixer_name("DSP1 Firmware", channel, ctl_name, sizeof(ctl_name));
@@ -839,6 +840,9 @@ retry_fw:
 
     if ((cspl_ena[0] + cspl_ena[1] + cspl_ena[2]) == 0 && cspl_ena[3] == 1) {
         ALOGI("%s: Cirrus %s Firmware Download SUCCESS.", __func__, fw_type);
+
+        /* Wait for the hardware to stabilize */
+        usleep(100000);
         ret = 0;
     } else {
         /*
@@ -854,6 +858,7 @@ retry_fw:
          */
         if (retry < CIRRUS_FIRMWARE_MAX_RETRY) {
             retry++;
+            ALOGI("%s: Retrying...\n", __func__);
             goto retry_fw;
         }
 
@@ -863,7 +868,6 @@ retry_fw:
     }
 
 exit:
-    usleep(10000);
     return ret;
 }
 
@@ -1113,6 +1117,61 @@ exit:
     return ret;
 }
 
+
+static int cirrus_write_cal_checksum(struct cirrus_cal_result_t *cal, char *lr)
+{
+    char ctl_name[CIRRUS_CTL_NAME_BUF];
+    int ret;
+
+    ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_CHECKSUM, lr,
+                                   ctl_name, sizeof(ctl_name));
+    if (ret < 0)
+        return ret;
+
+    ret = cirrus_set_mixer_array_by_name(ctl_name,
+                                         cal->checksum, 4);
+    if (ret >= 0)
+        goto exit;
+
+    /*
+     * On some firmwares the creativity level is high and the mixer
+     * names will be different.
+     */
+    ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_CHECKSUM_CD, lr,
+                                   ctl_name, sizeof(ctl_name));
+    if (ret < 0)
+        return ret;
+
+    ret = cirrus_set_mixer_array_by_name(ctl_name, cal->checksum, 4);
+exit:
+    return ret;
+}
+
+static int cirrus_write_cal_status(struct cirrus_cal_result_t *cal, char *lr)
+{
+    char ctl_name[CIRRUS_CTL_NAME_BUF];
+    int ret;
+
+    ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_STATUS, lr,
+                                   ctl_name, sizeof(ctl_name));
+    if (ret < 0)
+        return ret;
+
+    ret = cirrus_set_mixer_array_by_name(ctl_name,
+                                         cal->status, 4);
+    if (ret >= 0)
+        goto exit;
+
+    ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_STATUS_CD, lr,
+                                   ctl_name, sizeof(ctl_name));
+    if (ret < 0)
+        return ret;
+
+    ret = cirrus_set_mixer_array_by_name(ctl_name, cal->status, 4);
+exit:
+    return ret;
+}
+
 static int cirrus_do_fw_mono_download(int do_reset) {
     bool cal_valid = false, status_ok = false, checksum_ok = false;
     int ret = 0;
@@ -1170,16 +1229,16 @@ static int cirrus_do_fw_stereo_download(int do_reset) {
 
     ALOGI("%s: Sending speaker protection stereo firmware", __func__);
 
-    ret = cirrus_exec_fw_download("Protection", "L", do_reset);
+    ret = cirrus_exec_fw_download("Protection", "R", do_reset);
     if (ret != 0) {
-        ALOGE("%s: Cannot send Protection L firmware: bailing out.",
+        ALOGE("%s: Cannot send Protection R firmware: bailing out.",
               __func__);
         return -EINVAL;
     }
 
-    ret = cirrus_exec_fw_download("Protection", "R", do_reset);
+    ret = cirrus_exec_fw_download("Protection", "L", do_reset);
     if (ret != 0) {
-        ALOGE("%s: Cannot send Protection R firmware: bailing out.",
+        ALOGE("%s: Cannot send Protection L firmware: bailing out.",
               __func__);
         return -EINVAL;
     }
@@ -1193,17 +1252,6 @@ static int cirrus_do_fw_stereo_download(int do_reset) {
     if (ret < 0)
         goto exit;
 
-    ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_R, "L",
-                                    ctl_name, sizeof(ctl_name));
-    if (ret < 0)
-        return ret;
-    ret = cirrus_set_mixer_array_by_name(ctl_name,
-                                         &handle.spkl.cal_r, 4);
-    if (ret < 0) {
-        ALOGE("%s: Cannot set Z-L calibration", __func__);
-        goto exit;
-    }
-
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_R, "R",
                                     ctl_name, sizeof(ctl_name));
     if (ret < 0)
@@ -1215,47 +1263,38 @@ static int cirrus_do_fw_stereo_download(int do_reset) {
         goto exit;
     }
 
-    ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_STATUS, "L",
-                                    ctl_name, sizeof(ctl_name));
-    if (ret < 0)
-        return ret;
-    ret = cirrus_set_mixer_array_by_name(ctl_name,
-                                         &handle.spkl.status, 4);
-    if (ret < 0) {
-        ALOGE("%s: Cannot set calibration L status", __func__);
-        goto exit;
-    }
-
-    ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_STATUS, "R",
-                                    ctl_name, sizeof(ctl_name));
-    if (ret < 0)
-        return ret;
-    ret = cirrus_set_mixer_array_by_name(ctl_name,
-                                         &handle.spkr.status, 4);
+    ret = cirrus_write_cal_status(&handle.spkr, "R");
     if (ret < 0) {
         ALOGE("%s: Cannot set calibration R status", __func__);
         goto exit;
     }
 
-    ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_CHECKSUM, "L",
-                                    ctl_name, sizeof(ctl_name));
-    if (ret < 0)
-        return ret;
-    ret = cirrus_set_mixer_array_by_name(ctl_name,
-                                         &handle.spkl.checksum, 4);
+    ret = cirrus_write_cal_checksum(&handle.spkr, "R");
     if (ret < 0) {
-        ALOGE("%s: Cannot set checksum L", __func__);
+        ALOGE("%s: Cannot set checksum R", __func__);
         goto exit;
     }
 
-    ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_CHECKSUM, "R",
+    ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_R, "L",
                                     ctl_name, sizeof(ctl_name));
     if (ret < 0)
         return ret;
     ret = cirrus_set_mixer_array_by_name(ctl_name,
-                                         &handle.spkr.checksum, 4);
+                                         &handle.spkl.cal_r, 4);
     if (ret < 0) {
-        ALOGE("%s: Cannot set checksum R", __func__);
+        ALOGE("%s: Cannot set Z-L calibration", __func__);
+        goto exit;
+    }
+
+    ret = cirrus_write_cal_status(&handle.spkl, "L");
+    if (ret < 0) {
+        ALOGE("%s: Cannot set calibration L status", __func__);
+        goto exit;
+    }
+
+    ret = cirrus_write_cal_checksum(&handle.spkl, "L");
+    if (ret < 0) {
+        ALOGE("%s: Cannot set checksum L", __func__);
         goto exit;
     }
 

--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -49,8 +49,9 @@ static fp_platform_check_and_set_codec_backend_cfg_t fp_platform_check_and_set_c
 enum cirrus_playback_state {
     INIT = 0,
     CALIBRATING = 1,
-    IDLE = 2,
-    PLAYBACK = 3
+    CALIBRATION_ERROR = 2,
+    IDLE = 3,
+    PLAYBACK = 4
 };
 
 /* Payload struct for getting calibration result from DSP module */
@@ -82,7 +83,6 @@ struct cirrus_playback_session {
     pthread_t calibration_thread;
     pthread_t failure_detect_thread;
     struct pcm *pcm_rx;
-    struct pcm *pcm_tx;
     struct cirrus_cal_result_t spkl;
     struct cirrus_cal_result_t spkr;
     bool cirrus_drv_enabled;
@@ -603,7 +603,7 @@ static int cirrus_play_silence(int seconds) {
     uint8_t *silence = NULL;
     int i, ret = 0, silence_bytes, silence_cnt = 1;
     unsigned int buffer_size = 0, frames_bytes = 0;
-    int pcm_dev_rx_id;
+    int pcm_dev_rx_id, adev_retry = 5;
 
     if (!list_empty(&adev->usecase_list)) {
         ALOGD("%s: Usecase present retry speaker protection", __func__);
@@ -615,10 +615,10 @@ static int cirrus_play_silence(int seconds) {
         return -ENOMEM;
     }
 
-    while (!adev->primary_output) {
-        ALOGE("Still no primary_output!");
-        // TODO: Perhaps wait on a condvar like spkr_prot?
-        usleep(1000);
+    while ((!adev->primary_output || !adev->platform) && adev_retry) {
+        ALOGI("%s: Waiting for audio device...", __func__);
+        sleep(1);
+        adev_retry--;
     }
 
     uc_info_rx->id = USECASE_AUDIO_PLAYBACK_DEEP_BUFFER;
@@ -629,8 +629,10 @@ static int cirrus_play_silence(int seconds) {
     // list_init(&uc_info_rx->device_list);
     uc_info_rx->out_snd_device = SND_DEVICE_OUT_SPEAKER_PROTECTED;
     list_add_tail(&adev->usecase_list, &uc_info_rx->list);
+
     fp_platform_check_and_set_codec_backend_cfg(adev, uc_info_rx,
                                              uc_info_rx->out_snd_device);
+
     fp_enable_snd_device(adev, uc_info_rx->out_snd_device);
     fp_enable_audio_route(adev, uc_info_rx);
 
@@ -643,24 +645,18 @@ static int cirrus_play_silence(int seconds) {
     }
 
     handle.pcm_rx = pcm_open(adev->snd_card, pcm_dev_rx_id,
-                             PCM_OUT, &pcm_config_cirrus_rx);
+                             (PCM_OUT | PCM_MONOTONIC),
+                             &pcm_config_cirrus_rx);
     if (!handle.pcm_rx) {
         ALOGE("%s: Cannot open output PCM", __func__);
-        ret = -EINVAL;
+        ret = -EIO;
         goto exit;
     }
 
     if (!pcm_is_ready(handle.pcm_rx)) {
         ALOGE("%s: The PCM device is not ready: %s", __func__,
               pcm_get_error(handle.pcm_rx));
-        ret = -EINVAL;
-        goto exit;
-    }
-
-    if (pcm_start(handle.pcm_rx) < 0) {
-        ALOGE("%s: Cannot start PCM_RX: %s", __func__,
-              pcm_get_error(handle.pcm_rx));
-        ret = -EINVAL;
+        ret = -EIO;
         goto exit;
     }
 
@@ -684,18 +680,23 @@ static int cirrus_play_silence(int seconds) {
         if (ret) {
             ALOGE("%s: Cannot write PCM data: %d", __func__, ret);
             break;
-        }
+        } else
+            ALOGV("%s: Wrote PCM data", __func__);
     }
     ALOGD("%s: Stop playing silence audio", __func__);
     free(silence);
 
 exit:
+    if (handle.pcm_rx != NULL) {
+        pcm_close(handle.pcm_rx);
+        handle.pcm_rx = NULL;
+    }
+
     fp_disable_audio_route(adev, uc_info_rx);
     fp_disable_snd_device(adev, uc_info_rx->out_snd_device);
     list_remove(&uc_info_rx->list);
     free(uc_info_rx);
 
-    pcm_close(handle.pcm_rx);
     return ret;
 }
 
@@ -1269,10 +1270,13 @@ exit:
 }
 
 static void *cirrus_do_calibration() {
+    struct audio_device *adev = handle.adev_handle;
     int ret = 0, dev_file = -1;
     int prev_state = handle.state;
 
+    pthread_mutex_lock(&adev->lock);
     handle.state = CALIBRATING;
+    pthread_mutex_unlock(&adev->lock);
 
     if (prev_state == INIT)
         prev_state = IDLE;
@@ -1291,7 +1295,7 @@ static void *cirrus_do_calibration() {
         if (ret != 0) {
             ALOGE("%s: Cannot send Calibration firmware: bailing out.",
                   __func__);
-            handle.state = prev_state;
+            ret = -EINVAL;
             goto end;
         }
         /* Dual amp case */
@@ -1302,6 +1306,7 @@ static void *cirrus_do_calibration() {
         ret = cirrus_stereo_calibration();
     else
         ret = cirrus_mono_calibration();
+
     if (ret < 0) {
         ALOGE("%s: CRITICAL: Calibration failure", __func__);
         goto end;
@@ -1324,6 +1329,13 @@ skip_calibration:
         ALOGE("%s: Cannot send speaker protection FW", __func__);
 
 end:
+    pthread_mutex_lock(&adev->lock);
+    if (ret < 0)
+        handle.state = CALIBRATION_ERROR;
+    else
+        handle.state = IDLE;
+    pthread_mutex_unlock(&adev->lock);
+
     pthread_exit(0);
     return NULL;
 }
@@ -1469,6 +1481,24 @@ int spkr_prot_start_processing(__unused snd_device_t snd_device) {
 
     ret = cirrus_set_force_wake(true);
 
+    ALOGV("%s: current state %d", __func__, handle.state);
+
+    /*
+     * If we are still in calibration phase, we cannot play audio...
+     * and it's the same if we got an error during the process.
+     *
+     * Reason is that if we try playing audio during calibration, then
+     * the result will be bad and we will end up with a poorly calibrated
+     * speaker. Also, the DSP may get left in a bad state and not accept
+     * the protection firmware when we're ready for it.
+     */
+    if (handle.state == CALIBRATING || handle.state == CALIBRATION_ERROR) {
+        ALOGI("%s: Forbidden. Calibration %s", __func__,
+              handle.state == CALIBRATING ? "is in progress..." : "failed.");
+        ret = -1;
+        goto end;
+    }
+
     audio_route_apply_and_update_path(adev->audio_route,
                                       fp_platform_get_snd_device_name(snd_device));
 
@@ -1479,6 +1509,7 @@ int spkr_prot_start_processing(__unused snd_device_t snd_device) {
                     &handle);
 
     handle.state = PLAYBACK;
+end:
     pthread_mutex_unlock(&handle.fb_prot_mutex);
 
     ALOGV("%s: Exit", __func__);

--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -1212,7 +1212,7 @@ exit:
 
 static int cirrus_do_fw_mono_download(int do_reset) {
     bool cal_valid = false, status_ok = false, checksum_ok = false;
-    int i, max_retries = 24, ret = 0;
+    int i, max_retries = 32, ret = 0;
 
     for (i = 0; i < max_retries; i++) {
         ret = cirrus_exec_fw_download("Protection", 0, do_reset);
@@ -1266,7 +1266,7 @@ exit:
 static int cirrus_do_fw_stereo_download(int do_reset) {
     char ctl_name[CIRRUS_CTL_NAME_BUF];
     bool cal_valid = false, status_ok = false, checksum_ok = false;
-    int i, max_retries = 24, ret = 0;
+    int i, max_retries = 32, ret = 0;
 
     ALOGI("%s: Sending speaker protection stereo firmware", __func__);
 
@@ -1428,15 +1428,6 @@ static void *cirrus_do_calibration() {
         ALOGW("%s: Cannot save calibration to file (%d)!!!", __func__, ret);
         ret = 0;
     }
-
-    /*
-     * There is no way to know when the DSP will be really ready. Usually,
-     * it takes around 4 seconds, but let's wait a bit more... In any case
-     * the calibration process happens only *once* in an entire userdata
-     * life, which means that only the first boot ever will be slow, in
-     * favor of a good speaker calibration.
-     */
-    sleep(6);
 
 skip_calibration:
     if (handle.is_stereo)

--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -1212,9 +1212,14 @@ exit:
 
 static int cirrus_do_fw_mono_download(int do_reset) {
     bool cal_valid = false, status_ok = false, checksum_ok = false;
-    int ret = 0;
+    int i, max_retries = 24, ret = 0;
 
-    ret = cirrus_exec_fw_download("Protection", 0, do_reset);
+    for (i = 0; i < max_retries; i++) {
+        ret = cirrus_exec_fw_download("Protection", 0, do_reset);
+        if (ret == 0)
+            break;
+        usleep(500000);
+    }
     if (ret != 0) {
         ALOGE("%s: Cannot send Protection firmware: bailing out.",
               __func__);

--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -454,7 +454,7 @@ static int cirrus_set_mixer_value_by_name(char* ctl_name, int value) {
 
     ret = mixer_ctl_set_value(ctl_config, 0, value);
     if (ret < 0)
-        ALOGE("%s: Cannot set mixer %s value %d",
+        ALOGE("%s: Cannot set mixer '%s' to '%d'",
               __func__, ctl_name, value);
 exit:
     mixer_close(card_mixer);
@@ -470,7 +470,7 @@ static int cirrus_set_mixer_value_by_name_lr(char* ctl_base_name, int value) {
         return ret;
     ret = cirrus_set_mixer_value_by_name(ctl_name, value);
     if (ret < 0) {
-        ALOGE("%s: Cannot set mixer %s to %d", __func__, ctl_name, value);
+        ALOGE("%s: Cannot set mixer '%s' to '%d'", __func__, ctl_name, value);
         goto end;
     }
 
@@ -479,7 +479,7 @@ static int cirrus_set_mixer_value_by_name_lr(char* ctl_base_name, int value) {
         return ret;
     ret = cirrus_set_mixer_value_by_name(ctl_name, value);
     if (ret < 0)
-        ALOGE("%s: Cannot set mixer %s to %d", __func__, ctl_name, value);
+        ALOGE("%s: Cannot set mixer '%s' to '%d'", __func__, ctl_name, value);
 end:
     return ret;
 }
@@ -582,14 +582,14 @@ static int cirrus_set_mixer_enum_by_name(char* ctl_name, const char* value) {
 
     ctl_config = mixer_get_ctl_by_name(card_mixer, ctl_name);
     if (!ctl_config) {
-        ALOGE("%s: Cannot get mixer control %s", __func__, ctl_name);
+        ALOGE("%s: Cannot get mixer control '%s'", __func__, ctl_name);
         ret = -1;
         goto exit;
     }
 
     ret = mixer_ctl_set_enum_by_string(ctl_config, value);
     if (ret < 0)
-        ALOGE("%s: Cannot set mixer %s value %s",
+        ALOGE("%s: Cannot set mixer '%s' to '%s'",
               __func__, ctl_name, value);
 exit:
     mixer_close(card_mixer);
@@ -1595,6 +1595,14 @@ int spkr_prot_start_processing(__unused snd_device_t snd_device) {
         return -EINVAL;
     }
 
+    if (pthread_self() == handle.calibration_thread) {
+        // Succeed without doing anything; the calibration already
+        // selects the right paths, and we do not want the failure
+        // detect thread to run just yet.
+        ALOGV("%s: We are the calibration thread", __func__);
+        goto end;
+    }
+
     pthread_mutex_lock(&handle.fb_prot_mutex);
 
     ret = cirrus_set_force_wake(true);
@@ -1640,13 +1648,28 @@ void spkr_prot_stop_processing(__unused snd_device_t snd_device) {
 
     ALOGV("%s: Entry", __func__);
 
-    audio_route_reset_and_update_path(adev->audio_route,
-                                      fp_platform_get_snd_device_name(snd_device));
-
     pthread_mutex_lock(&handle.fb_prot_mutex);
+
+    if (pthread_self() == handle.calibration_thread) {
+        // This happens when stopping the device from calibration. We bailed
+        // and never set PLAYBACK, so we should also never update the audio
+        // route nor unconditionally set the state back to IDLE
+        ALOGV("%s: We are the calibration thread", __func__);
+        goto end;
+    }
+
+    if (handle.state != PLAYBACK) {
+        ALOGE("%s: Cannot stop processing, state is not PLAYBACK (but %d)",
+              __func__, handle.state);
+        goto end;
+    }
 
     handle.state = IDLE;
 
+    audio_route_reset_and_update_path(adev->audio_route,
+                                      fp_platform_get_snd_device_name(snd_device));
+
+end:
     pthread_mutex_unlock(&handle.fb_prot_mutex);
 
     (void)cirrus_set_force_wake(false);

--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -44,6 +44,7 @@ static fp_enable_disable_snd_device_t fp_disable_snd_device;
 static fp_enable_disable_snd_device_t  fp_enable_snd_device;
 static fp_enable_disable_audio_route_t fp_disable_audio_route;
 static fp_enable_disable_audio_route_t fp_enable_audio_route;
+static fp_platform_check_and_set_codec_backend_cfg_t fp_platform_check_and_set_codec_backend_cfg;
 
 enum cirrus_playback_state {
     INIT = 0,
@@ -380,6 +381,7 @@ void spkr_prot_init(void *adev, spkr_prot_init_config_t spkr_prot_init_config_va
     fp_enable_snd_device = spkr_prot_init_config_val.fp_enable_snd_device;
     fp_disable_audio_route = spkr_prot_init_config_val.fp_disable_audio_route;
     fp_enable_audio_route = spkr_prot_init_config_val.fp_enable_audio_route;
+    fp_platform_check_and_set_codec_backend_cfg = spkr_prot_init_config_val.fp_platform_check_and_set_codec_backend_cfg;
 
     pthread_mutex_init(&handle.fb_prot_mutex, NULL);
 
@@ -592,13 +594,42 @@ static int cirrus_play_silence(int seconds) {
     struct audio_device *adev = handle.adev_handle;
     struct mixer_ctl *ctl_config = NULL;
     struct pcm_config rx_tmp = { 0 };
+    struct audio_usecase *uc_info_rx;
 
     uint8_t *silence = NULL;
     int i, ret = 0, silence_bytes, silence_cnt = 1;
     unsigned int buffer_size = 0, frames_bytes = 0;
-    int pcm_dev_rx_id = fp_platform_get_pcm_device_id(USECASE_AUDIO_PLAYBACK_DEEP_BUFFER, PCM_PLAYBACK);
+    int pcm_dev_rx_id;
 
-    audio_route_apply_and_update_path(adev->audio_route, "deep-buffer-playback");
+    if (!list_empty(&adev->usecase_list)) {
+        ALOGD("%s: Usecase present retry speaker protection", __func__);
+        return -EAGAIN;
+    }
+
+    uc_info_rx = (struct audio_usecase *)calloc(1, sizeof(struct audio_usecase));
+    if (!uc_info_rx) {
+        return -ENOMEM;
+    }
+    uc_info_rx->id = USECASE_AUDIO_PLAYBACK_DEEP_BUFFER;
+    uc_info_rx->type = PCM_PLAYBACK;
+    uc_info_rx->in_snd_device = SND_DEVICE_NONE;
+    uc_info_rx->stream.out = adev->primary_output;
+    // device_list is not available on q-mr1
+    // list_init(&uc_info_rx->device_list);
+    uc_info_rx->out_snd_device = SND_DEVICE_OUT_SPEAKER_PROTECTED;
+    list_add_tail(&adev->usecase_list, &uc_info_rx->list);
+    fp_platform_check_and_set_codec_backend_cfg(adev, uc_info_rx,
+                                             uc_info_rx->out_snd_device);
+    fp_enable_snd_device(adev, uc_info_rx->out_snd_device);
+    fp_enable_audio_route(adev, uc_info_rx);
+
+    pcm_dev_rx_id = fp_platform_get_pcm_device_id(uc_info_rx->id, PCM_PLAYBACK);
+    ALOGV("%s: pcm device id %d", __func__, pcm_dev_rx_id);
+    if (pcm_dev_rx_id < 0) {
+        ALOGE("%s: Invalid pcm device for usecase (%d)",
+              __func__, uc_info_rx->id);
+        goto exit;
+    }
 
     handle.pcm_rx = pcm_open(adev->snd_card, pcm_dev_rx_id,
                              PCM_OUT, &pcm_config_cirrus_rx);
@@ -648,7 +679,10 @@ static int cirrus_play_silence(int seconds) {
     free(silence);
 
 exit:
-    audio_route_reset_and_update_path(adev->audio_route, "deep-buffer-playback");
+    fp_disable_audio_route(adev, uc_info_rx);
+    fp_disable_snd_device(adev, uc_info_rx->out_snd_device);
+    list_remove(&uc_info_rx->list);
+    free(uc_info_rx);
 
     pcm_close(handle.pcm_rx);
     return ret;

--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -464,14 +464,18 @@ static int cirrus_set_mixer_value_by_name_lr(char* ctl_base_name, int value) {
     int ret = 0;
 
     ret = cirrus_format_mixer_name(ctl_base_name, "L", ctl_name, sizeof(ctl_name));
-    ret += cirrus_set_mixer_value_by_name(ctl_name, value);
+    if (ret < 0)
+        return ret;
+    ret = cirrus_set_mixer_value_by_name(ctl_name, value);
     if (ret < 0) {
         ALOGE("%s: Cannot set mixer %s to %d", __func__, ctl_name, value);
         goto end;
     }
 
     ret = cirrus_format_mixer_name(ctl_base_name, "R", ctl_name, sizeof(ctl_name));
-    ret += cirrus_set_mixer_value_by_name(ctl_name, value);
+    if (ret < 0)
+        return ret;
+    ret = cirrus_set_mixer_value_by_name(ctl_name, value);
     if (ret < 0)
         ALOGE("%s: Cannot set mixer %s to %d", __func__, ctl_name, value);
 end:
@@ -720,7 +724,9 @@ static int cirrus_do_reset(const char *channel) {
     int ret = 0;
 
     ret = cirrus_format_mixer_name("CCM Reset", channel, ctl_name, sizeof(ctl_name));
-    ret += cirrus_get_mixer_value_by_name(ctl_name);
+    if (ret < 0)
+        return ret;
+    ret = cirrus_get_mixer_value_by_name(ctl_name);
     if (ret < 0) {
         ALOGE("%s: CCM Reset is missing!!!", __func__);
     } else {
@@ -745,7 +751,9 @@ static int cirrus_exec_fw_download(const char *fw_type, const char *channel,
 
     /* If this one is missing, we're not using our Cirrus codec... */
     ret = cirrus_format_mixer_name("DSP Booted", channel, ctl_name, sizeof(ctl_name));
-    ret += cirrus_get_mixer_value_by_name(ctl_name);
+    if (ret < 0)
+        return ret;
+    ret = cirrus_get_mixer_value_by_name(ctl_name);
     if (ret < 0) {
         ALOGE("%s: %s control is missing. Bailing out.", __func__, ctl_name);
         ret = -ENODEV;
@@ -763,7 +771,9 @@ static int cirrus_exec_fw_download(const char *fw_type, const char *channel,
 
     ret = cirrus_format_mixer_name("DSP1 Preload Switch",
                                    channel, ctl_name, sizeof(ctl_name));
-    ret += cirrus_set_mixer_value_by_name(ctl_name, 0);
+    if (ret < 0)
+        return ret;
+    ret = cirrus_set_mixer_value_by_name(ctl_name, 0);
     if (ret < 0) {
         ALOGE("%s: Cannot reset %s", __func__, ctl_name);
         goto exit;
@@ -772,14 +782,18 @@ static int cirrus_exec_fw_download(const char *fw_type, const char *channel,
 
     /* Determine what firmware to load and configure DSP */
     ret = cirrus_format_mixer_name("DSP1 Firmware", channel, ctl_name, sizeof(ctl_name));
-    ret += cirrus_set_mixer_enum_by_name(ctl_name, fw_type);
+    if (ret < 0)
+        return ret;
+    ret = cirrus_set_mixer_enum_by_name(ctl_name, fw_type);
     if (ret < 0) {
         ALOGE("%s: Cannot set %s to %s", __func__, ctl_name, fw_type);
         goto exit;
     }
 
     ret = cirrus_format_mixer_name("PCM Source", channel, ctl_name, sizeof(ctl_name));
-    ret += cirrus_set_mixer_enum_by_name(ctl_name, "DSP");
+    if (ret < 0)
+        return ret;
+    ret = cirrus_set_mixer_enum_by_name(ctl_name, "DSP");
     if (ret < 0) {
         ALOGE("%s: Cannot set %s to DSP", __func__, ctl_name);
         goto exit;
@@ -788,7 +802,9 @@ static int cirrus_exec_fw_download(const char *fw_type, const char *channel,
     /* Send the firmware! */
     ret = cirrus_format_mixer_name("DSP1 Preload Switch",
                                    channel, ctl_name, sizeof(ctl_name));
-    ret += cirrus_set_mixer_value_by_name(ctl_name, 1);
+    if (ret < 0)
+        return ret;
+    ret = cirrus_set_mixer_value_by_name(ctl_name, 1);
     if (ret < 0) {
         ALOGE("%s: Cannot set %s to %s", __func__, ctl_name, fw_type);
         goto exit;
@@ -996,7 +1012,9 @@ static int cirrus_stereo_calibration(void) {
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_CALI_CAL_STATUS, "L",
                                    ctl_name, sizeof(ctl_name));
-    ret += cirrus_get_mixer_array_by_name(ctl_name,
+    if (ret < 0)
+        return ret;
+    ret = cirrus_get_mixer_array_by_name(ctl_name,
                                           &handle.spkl.status, 4);
     if (ret < 0) {
         ALOGE("%s: Cannot get %s", __func__, ctl_name);
@@ -1005,7 +1023,9 @@ static int cirrus_stereo_calibration(void) {
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_CALI_CAL_STATUS, "R",
                                    ctl_name, sizeof(ctl_name));
-    ret += cirrus_get_mixer_array_by_name(ctl_name,
+    if (ret < 0)
+        return ret;
+    ret = cirrus_get_mixer_array_by_name(ctl_name,
                                           &handle.spkr.status, 4);
     if (ret < 0) {
         ALOGE("%s: Cannot get %s", __func__, ctl_name);
@@ -1038,7 +1058,9 @@ static int cirrus_stereo_calibration(void) {
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_CALI_CAL_CHECKSUM, "L",
                                    ctl_name, sizeof(ctl_name));
-    ret += cirrus_get_mixer_array_by_name(ctl_name,
+    if (ret < 0)
+        return ret;
+    ret = cirrus_get_mixer_array_by_name(ctl_name,
                                          &handle.spkl.checksum, 4);
     if (ret < 0) {
         ALOGE("%s: Cannot get %s", __func__, ctl_name);
@@ -1047,7 +1069,9 @@ static int cirrus_stereo_calibration(void) {
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_CALI_CAL_CHECKSUM, "R",
                                    ctl_name, sizeof(ctl_name));
-    ret += cirrus_get_mixer_array_by_name(ctl_name,
+    if (ret < 0)
+        return ret;
+    ret = cirrus_get_mixer_array_by_name(ctl_name,
                                          &handle.spkr.checksum, 4);
     if (ret < 0) {
         ALOGE("%s: Cannot get %s", __func__, ctl_name);
@@ -1056,7 +1080,9 @@ static int cirrus_stereo_calibration(void) {
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_CALI_CAL_R, "L",
                                    ctl_name, sizeof(ctl_name));
-    ret += cirrus_get_mixer_array_by_name(ctl_name,
+    if (ret < 0)
+        return ret;
+    ret = cirrus_get_mixer_array_by_name(ctl_name,
                                          &handle.spkl.cal_r, 4);
     if (ret < 0) {
         ALOGE("%s: Cannot get %s", __func__, ctl_name);
@@ -1065,7 +1091,9 @@ static int cirrus_stereo_calibration(void) {
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_CALI_CAL_R, "R",
                                    ctl_name, sizeof(ctl_name));
-    ret += cirrus_get_mixer_array_by_name(ctl_name,
+    if (ret < 0)
+        return ret;
+    ret = cirrus_get_mixer_array_by_name(ctl_name,
                                          &handle.spkr.cal_r, 4);
     if (ret < 0) {
         ALOGE("%s: Cannot get %s", __func__, ctl_name);
@@ -1166,7 +1194,9 @@ static int cirrus_do_fw_stereo_download(int do_reset) {
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_R, "L",
                                     ctl_name, sizeof(ctl_name));
-    ret += cirrus_set_mixer_array_by_name(ctl_name,
+    if (ret < 0)
+        return ret;
+    ret = cirrus_set_mixer_array_by_name(ctl_name,
                                          &handle.spkl.cal_r, 4);
     if (ret < 0) {
         ALOGE("%s: Cannot set Z-L calibration", __func__);
@@ -1175,7 +1205,9 @@ static int cirrus_do_fw_stereo_download(int do_reset) {
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_R, "R",
                                     ctl_name, sizeof(ctl_name));
-    ret += cirrus_set_mixer_array_by_name(ctl_name,
+    if (ret < 0)
+        return ret;
+    ret = cirrus_set_mixer_array_by_name(ctl_name,
                                          &handle.spkr.cal_r, 4);
     if (ret < 0) {
         ALOGE("%s: Cannot set Z-R calibration", __func__);
@@ -1184,7 +1216,9 @@ static int cirrus_do_fw_stereo_download(int do_reset) {
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_STATUS, "L",
                                     ctl_name, sizeof(ctl_name));
-    ret += cirrus_set_mixer_array_by_name(ctl_name,
+    if (ret < 0)
+        return ret;
+    ret = cirrus_set_mixer_array_by_name(ctl_name,
                                          &handle.spkl.status, 4);
     if (ret < 0) {
         ALOGE("%s: Cannot set calibration L status", __func__);
@@ -1193,7 +1227,9 @@ static int cirrus_do_fw_stereo_download(int do_reset) {
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_STATUS, "R",
                                     ctl_name, sizeof(ctl_name));
-    ret += cirrus_set_mixer_array_by_name(ctl_name,
+    if (ret < 0)
+        return ret;
+    ret = cirrus_set_mixer_array_by_name(ctl_name,
                                          &handle.spkr.status, 4);
     if (ret < 0) {
         ALOGE("%s: Cannot set calibration R status", __func__);
@@ -1202,7 +1238,9 @@ static int cirrus_do_fw_stereo_download(int do_reset) {
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_CHECKSUM, "L",
                                     ctl_name, sizeof(ctl_name));
-    ret += cirrus_set_mixer_array_by_name(ctl_name,
+    if (ret < 0)
+        return ret;
+    ret = cirrus_set_mixer_array_by_name(ctl_name,
                                          &handle.spkl.checksum, 4);
     if (ret < 0) {
         ALOGE("%s: Cannot set checksum L", __func__);
@@ -1211,7 +1249,9 @@ static int cirrus_do_fw_stereo_download(int do_reset) {
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CAL_CHECKSUM, "R",
                                     ctl_name, sizeof(ctl_name));
-    ret += cirrus_set_mixer_array_by_name(ctl_name,
+    if (ret < 0)
+        return ret;
+    ret = cirrus_set_mixer_array_by_name(ctl_name,
                                          &handle.spkr.checksum, 4);
     if (ret < 0) {
         ALOGE("%s: Cannot set checksum R", __func__);
@@ -1324,7 +1364,9 @@ static int cirrus_check_error_state_stereo(void) {
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CSPL_ERRORNO, "L",
                                    ctl_name, sizeof(ctl_name));
-    ret += cirrus_get_mixer_array_by_name(ctl_name, &cspl_error, 4);
+    if (ret < 0)
+        return ret;
+    ret = cirrus_get_mixer_array_by_name(ctl_name, &cspl_error, 4);
     if (ret < 0) {
         ALOGE("%s: Cannot get %s", __func__, ctl_name);
         goto exit;
@@ -1338,7 +1380,9 @@ static int cirrus_check_error_state_stereo(void) {
 
     ret = cirrus_format_mixer_name(CIRRUS_CTL_PROT_CSPL_ERRORNO, "R",
                                    ctl_name, sizeof(ctl_name));
-    ret += cirrus_get_mixer_array_by_name(ctl_name, &cspl_error, 4);
+    if (ret < 0)
+        return ret;
+    ret = cirrus_get_mixer_array_by_name(ctl_name, &cspl_error, 4);
     if (ret < 0) {
         ALOGE("%s: Cannot get %s", __func__, ctl_name);
         goto exit;

--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -141,8 +141,8 @@ int (*miscta_write_unit)(uint32_t id, const void *buf, uint32_t size) = NULL;
 #define CIRRUS_CTL_NAME_BUF 40
 #define CIRRUS_ERROR_DETECT_SLEEP_US	250000
 
-#define CIRRUS_FIRMWARE_LOAD_SLEEP_US	2500
-#define CIRRUS_FIRMWARE_MAX_RETRY	10
+#define CIRRUS_FIRMWARE_LOAD_SLEEP_US	5000
+#define CIRRUS_FIRMWARE_MAX_RETRY	30
 
 /* Saved calibrations */
 #ifndef CIRRUS_AUDIO_CAL_PATH
@@ -525,7 +525,7 @@ static int cirrus_set_mixer_array_by_name(char* ctl_name,
 
     ctl_config = mixer_get_ctl_by_name(card_mixer, ctl_name);
     if (!ctl_config) {
-        ALOGE("%s: Cannot get mixer control %s", __func__, ctl_name);
+        ALOGD("%s: Cannot get mixer control %s", __func__, ctl_name);
         ret = -1;
         goto exit;
     }
@@ -696,6 +696,7 @@ exit:
 
     fp_disable_audio_route(adev, uc_info_rx);
     fp_disable_snd_device(adev, uc_info_rx->out_snd_device);
+
     list_remove(&uc_info_rx->list);
     free(uc_info_rx);
 
@@ -740,6 +741,24 @@ static int cirrus_do_reset(const char *channel) {
     return ret;
 }
 
+static int cirrus_mixer_wait_for_setting(char *ctl, int val, int retry)
+{
+    int i, ret;
+
+    for (i = 0; i < retry; i++) {
+        /* Start firmware download sequence: shut down DSP and reset states */
+        ret = cirrus_get_mixer_value_by_name(ctl);
+        if (ret < 0 || ret == val)
+            break;
+
+        usleep(10000);
+    }
+    if (ret < 0 && i == retry)
+        return -ETIMEDOUT;
+
+    return ret;
+}
+
 static int cirrus_exec_fw_download(const char *fw_type, const char *channel,
                                    int do_reset) {
     char ctl_name[CIRRUS_CTL_NAME_BUF];
@@ -769,6 +788,13 @@ static int cirrus_exec_fw_download(const char *fw_type, const char *channel,
         ALOGE("%s: Cannot reset %s status", __func__, ctl_name);
         goto exit;
     }
+
+    ret = cirrus_mixer_wait_for_setting(ctl_name, 0, 10);
+    if (ret < 0) {
+        ALOGE("%s: %s wait setting error %d", __func__, ctl_name, ret);
+        goto exit;
+    }
+
     usleep(10000);
 
     ret = cirrus_format_mixer_name("DSP1 Preload Switch",
@@ -780,6 +806,13 @@ static int cirrus_exec_fw_download(const char *fw_type, const char *channel,
         ALOGE("%s: Cannot reset %s", __func__, ctl_name);
         goto exit;
     }
+
+    ret = cirrus_mixer_wait_for_setting(ctl_name, 0, 10);
+    if (ret < 0) {
+        ALOGE("%s: %s wait setting error %d", __func__, ctl_name, ret);
+        goto exit;
+    }
+
     usleep(10000);
 
     /* Determine what firmware to load and configure DSP */
@@ -834,13 +867,18 @@ retry_fw:
 
     ret = cirrus_get_mixer_array_by_name(ctl_name, &cspl_ena, 4);
     if (ret < 0) {
-        ALOGE("%s: Cannot get %s stats", __func__, ctl_name);
-        goto exit;
+        if (retry < CIRRUS_FIRMWARE_MAX_RETRY) {
+            retry++;
+            ALOGI("%s: Retrying...\n", __func__);
+            goto retry_fw;
+        } else {
+            ALOGE("%s: Cannot get %s stats", __func__, ctl_name);
+            goto exit;
+        }
     }
 
     if ((cspl_ena[0] + cspl_ena[1] + cspl_ena[2]) == 0 && cspl_ena[3] == 1) {
         ALOGI("%s: Cirrus %s Firmware Download SUCCESS.", __func__, fw_type);
-
         /* Wait for the hardware to stabilize */
         usleep(100000);
         ret = 0;
@@ -1306,17 +1344,31 @@ exit:
     return ret;
 }
 
+static int cirrus_do_fw_calibration_download(struct cirrus_playback_session *hdl)
+{
+    int ret = 0;
+
+    ret = cirrus_exec_fw_download("Calibration", 0, 0);
+    if (ret < 0) {
+        ret = cirrus_exec_fw_download("Calibration", "L", 0);
+        ret += cirrus_exec_fw_download("Calibration", "R", 0);
+        if (ret != 0)
+            return ret;
+
+        /* Dual amp case */
+        hdl->is_stereo = true;
+    }
+
+    return ret;
+}
+
 static void *cirrus_do_calibration() {
     struct audio_device *adev = handle.adev_handle;
     int ret = 0, dev_file = -1;
-    int prev_state = handle.state;
 
     pthread_mutex_lock(&adev->lock);
     handle.state = CALIBRATING;
     pthread_mutex_unlock(&adev->lock);
-
-    if (prev_state == INIT)
-        prev_state = IDLE;
 
     if (handle.spkl.cal_ok && handle.spkr.cal_ok)
         goto skip_calibration;
@@ -1325,18 +1377,12 @@ static void *cirrus_do_calibration() {
            __func__, cal_ambient[0], cal_ambient[1], cal_ambient[2],
            cal_ambient[3]);
 
-    ret = cirrus_exec_fw_download("Calibration", 0, 0);
-    if (ret < 0) {
-        ret = cirrus_exec_fw_download("Calibration", "L", 0);
-        ret += cirrus_exec_fw_download("Calibration", "R", 0);
-        if (ret != 0) {
-            ALOGE("%s: Cannot send Calibration firmware: bailing out.",
-                  __func__);
-            ret = -EINVAL;
-            goto end;
-        }
-        /* Dual amp case */
-        handle.is_stereo = true;
+    ret = cirrus_do_fw_calibration_download(&handle);
+    if (ret != 0) {
+        ALOGE("%s: Cannot send Calibration firmware: bailing out.",
+              __func__);
+        ret = -EINVAL;
+        goto end;
     }
 
     if (handle.is_stereo)
@@ -1348,7 +1394,8 @@ static void *cirrus_do_calibration() {
         ALOGE("%s: CRITICAL: Calibration failure", __func__);
         goto end;
     }
-    ALOGI("%s: Calibration success", __func__);
+    ALOGI("%s: Calibration success! Saving state and waiting for DSP...",
+          __func__);
 
     ret = cirrus_save_calibration(&handle);
     if (ret) {
@@ -1356,6 +1403,15 @@ static void *cirrus_do_calibration() {
         ALOGW("%s: Cannot save calibration to file (%d)!!!", __func__, ret);
         ret = 0;
     }
+
+    /*
+     * There is no way to know when the DSP will be really ready. Usually,
+     * it takes around 4 seconds, but let's wait a bit more... In any case
+     * the calibration process happens only *once* in an entire userdata
+     * life, which means that only the first boot ever will be slow, in
+     * favor of a good speaker calibration.
+     */
+    sleep(6);
 
 skip_calibration:
     if (handle.is_stereo)

--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -1198,15 +1198,13 @@ static int cirrus_do_fw_mono_download(int do_reset) {
         goto exit;
     }
 
-    ret = cirrus_set_mixer_array_by_name(CIRRUS_CTL_CALI_CAL_STATUS,
-                                         &handle.spkr.status, 4);
+    ret = cirrus_write_cal_status(&handle.spkr, 0);
     if (ret < 0) {
         ALOGE("%s: Cannot set calibration status", __func__);
         goto exit;
     }
 
-    ret = cirrus_set_mixer_array_by_name(CIRRUS_CTL_CALI_CAL_CHECKSUM,
-                                         &handle.spkr.checksum, 4);
+    ret = cirrus_write_cal_checksum(&handle.spkr, 0);
     if (ret < 0) {
         ALOGE("%s: Cannot set calibration checksum", __func__);
         goto exit;


### PR DESCRIPTION
On SailfishOS we observe that the calibration of the cirrus device fails, noticeable by a frequency sweep noise during bootup.
Fix this by cherry-picking the related fixed from the aosp/LA.UM.9.12.r1 branch. And also fix the calibration for mono.

Part 1: Cherry-pick #20 and #21 onto q-mr1 and fix conflicts.
Part 2:
64f5f623ecbd29f87183a0036826e286390b01bf: Seems in mono calibration the different firmware names need to be accounted for too. Probably good to cherry-pick this onto aosp/LA.UM.9.12.r1 too.
af0763aa113bcb2a4a0982d3210e623da593d8a6: Initially i thought this was my issue but it turned out it wasn't, but i guess it's still a nice addition. Can drop if wanted.