### PR TITLE
[audio] [q-mr1] cirrus_sony: Don't set force wake when already calibrating

### DIFF
--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -1596,8 +1596,6 @@ int spkr_prot_start_processing(__unused snd_device_t snd_device) {
 
     pthread_mutex_lock(&handle.fb_prot_mutex);
 
-    ret = cirrus_set_force_wake(true);
-
     ALOGV("%s: current state %d", __func__, handle.state);
 
     /*
@@ -1615,6 +1613,8 @@ int spkr_prot_start_processing(__unused snd_device_t snd_device) {
         ret = -1;
         goto end;
     }
+
+    ret = cirrus_set_force_wake(true);
 
     audio_route_apply_and_update_path(adev->audio_route,
                                       fp_platform_get_snd_device_name(snd_device));


### PR DESCRIPTION
The calibration process should not be interrupted in any way by poking random mixers, when playback is forbidden while calibration is ongoing. @krnlyng This fixes conflict resolution in 2575faa18 ("cirrus_sony: Redo PCM handling for calibration, add locking").

Preferably this is amended as it has been squashed into the offending patch in #23, to keep history similar enough to allow for comparison and future backports (hoping we have none... :crossed_fingers:).