### PR TITLE
cirrus_sony: Correctly load calibration data from TA if specified

### DIFF
--- a/hal/audio_extn/Android.mk
+++ b/hal/audio_extn/Android.mk
@@ -381,6 +381,10 @@ LOCAL_SRC_FILES:= \
         cirrus_playback.c
 endif
 
+ifeq ($(strip $(AUDIO_FEATURE_SONY_CIRRUS_CALIB_TA)),true)
+LOCAL_CFLAGS += -DGET_SPEAKER_CALIBRATIONS_FROM_TA
+endif
+
 LOCAL_CFLAGS += \
     -Wall \
     -Werror \

--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -196,7 +196,7 @@ static int get_ta_array(uint32_t unit, void *arr, bool reverse) {
         goto end;
 
     /* Invert the array, because TA has the values inverted... */
-    for (i = 0; i <= ta_sz / 2; i++) {
+    for (i = 0; i < ta_sz / 2; i++) {
         tmp = array[i];
         array[i] = array[ta_sz - i - 1];
         array[ta_sz - i - 1] = tmp;

--- a/hal/audio_extn/cirrus_sony.c
+++ b/hal/audio_extn/cirrus_sony.c
@@ -363,7 +363,16 @@ void spkr_prot_init(void *adev, spkr_prot_init_config_t spkr_prot_init_config_va
                        &handle.spkr.checksum, true);
     if (ret)
         return;
-#endif
+
+    handle.spkl.cal_ok = true;
+    handle.spkr.cal_ok = true;
+
+    int spkl_empty = 0;
+    for (i = 0; i < 4; i ++) {
+      spkl_empty |= handle.spkl.cal_r[i];
+    }
+    handle.is_stereo = spkl_empty != 0;
+#else
 
     /* Do we want to load or calibrate? */
     ret = cirrus_cal_from_file(&handle);
@@ -374,6 +383,7 @@ void spkr_prot_init(void *adev, spkr_prot_init_config_t spkr_prot_init_config_va
         handle.spkl.cal_ok = false;
         handle.spkr.cal_ok = false;
     }
+#endif
 
     // init function pointers
     fp_platform_get_snd_device_name = spkr_prot_init_config_val.fp_platform_get_snd_device_name;


### PR DESCRIPTION
* If the device's TA partition contains calibration data for the speaker,
  set the AUDIO_FEATURE_SONY_CIRRUS_CALIB_TA flag to instruct cirrus_sony
  module to load calibration data from TA partition.

* Fix the TA array inversion implementation.