### PR TITLE
[9.16.r1] Android.mk: Protect with TARGET_USES_AUDIOREACH flag

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,0 +1,2 @@
+soong_namespace {
+}

--- a/Android.mk
+++ b/Android.mk
@@ -1,4 +1,4 @@
-ifneq ($(DUAL_AUDIO_FRAMEWORK_AR), true)
+ifneq ($(TARGET_USES_AUDIOREACH), true)
 ifneq ($(AUDIO_USE_STUB_HAL), true)
 ifneq ($(filter mpq8092 msm8960 msm8226 msm8x26 msm8610 msm8974 msm8x74 apq8084 msm8916 msm8994 msm8992 msm8909 msm8996 msm8952 msm8937 thorium msm8953 msmgold msm8998 sdm660 sdm845 sdm710 apq8098_latv qcs605 sdmshrike $(MSMNILE) $(KONA) $(LAHAINA) $(HOLI) $(MSMSTEPPE) $(TRINKET) atoll $(LITO) bengal,$(TARGET_BOARD_PLATFORM)),)
 


### PR DESCRIPTION
It so happened that we have a new Audioreach based HAL and legacy
one (pre SM8450 SoC)  at the same time. They use the same module
names, so we must protect them to compile the required one and
prevent conflicts.