### PR TITLE
[9.16.r1] hal: Use 64bit path for soundtrigger lib

### DIFF
--- a/hal/audio_extn/gef.c
+++ b/hal/audio_extn/gef.c
@@ -58,7 +58,11 @@
 #if LINUX_ENABLED
 #define GEF_LIBRARY "libqtigef.so"
 #else
+#ifdef __LP64__
+#define GEF_LIBRARY "/vendor/lib64/libqtigef.so"
+#else
 #define GEF_LIBRARY "/vendor/lib/libqtigef.so"
+#endif
 #endif
 
 typedef void* (*gef_init_t)(void*);

--- a/hal/audio_extn/ip_hdlr_intf.c
+++ b/hal/audio_extn/ip_hdlr_intf.c
@@ -39,7 +39,11 @@
 #ifdef LINUX_ENABLED
 #define LIB_PATH "libaudio_ip_handler.so"
 #else
+#ifdef __LP64__
+#define LIB_PATH "/system/vendor/lib64/libaudio_ip_handler.so"
+#else
 #define LIB_PATH "/system/vendor/lib/libaudio_ip_handler.so"
+#endif
 #endif
 
 #include <pthread.h>

--- a/hal/audio_extn/listen.c
+++ b/hal/audio_extn/listen.c
@@ -49,7 +49,11 @@
 
 #ifdef AUDIO_LISTEN_ENABLED
 
+#ifdef __LP64__
+#define LIB_LISTEN_LOADER "/vendor/lib64/liblistenhardware.so"
+#else
 #define LIB_LISTEN_LOADER "/vendor/lib/liblistenhardware.so"
+#endif
 
 #define LISTEN_LOAD_SYMBOLS(dev, func_p, func_type, symbol) \
 {\

--- a/hal/audio_extn/soundtrigger.c
+++ b/hal/audio_extn/soundtrigger.c
@@ -226,8 +226,7 @@ static void get_library_path(char *lib_path)
 static void get_library_path(char *lib_path)
 {
     snprintf(lib_path, MAX_LIBRARY_PATH,
-             "/vendor/lib/hw/sound_trigger.primary.%s.so",
-             XSTR(SOUND_TRIGGER_PLATFORM_NAME));
+             SOUND_TRIGGER_LIBRARY_PATH, XSTR(SOUND_TRIGGER_PLATFORM_NAME));
 }
 #endif
 

--- a/hal/audio_extn/spkr_protection.c
+++ b/hal/audio_extn/spkr_protection.c
@@ -92,6 +92,12 @@
 #include <log_utils.h>
 #endif
 
+#ifdef __LP64__
+#define LIB_THERMAL_CLIENT "/vendor/lib64/libthermalclient.so"
+#else
+#define LIB_THERMAL_CLIENT "/vendor/lib/libthermalclient.so"
+#endif
+
 #ifdef SPKR_PROT_ENABLED
 
 /*Range of spkr temparatures -30C to 80C*/
@@ -2321,8 +2327,7 @@ void spkr_prot_init(void *adev, spkr_prot_init_config_t spkr_prot_init_config_va
     pthread_mutex_init(&handle.mutex_spkr_prot, NULL);
     pthread_mutex_init(&handle.spkr_calib_cancelack_mutex, NULL);
     pthread_mutex_init(&handle.spkr_prot_thermalsync_mutex, NULL);
-    handle.thermal_handle = dlopen("/vendor/lib/libthermalclient.so",
-            RTLD_NOW);
+    handle.thermal_handle = dlopen(LIB_THERMAL_CLIENT, RTLD_NOW);
     if (!handle.thermal_handle) {
         ALOGE("%s: DLOPEN for thermal client failed", __func__);
     } else {

--- a/post_proc/Android.mk
+++ b/post_proc/Android.mk
@@ -3,7 +3,7 @@ LOCAL_PATH:= $(call my-dir)
 
 include $(CLEAR_VARS)
 
-LOCAL_CFLAGS := -DLIB_AUDIO_HAL="/vendor/lib/hw/audio.primary."$(TARGET_BOARD_PLATFORM)".so"
+LOCAL_CFLAGS := -DPRIMARY_HAL_PLATFORM_NAME=$(TARGET_BOARD_PLATFORM)
 LOCAL_CFLAGS += -Wno-unused-variable
 LOCAL_CFLAGS += -Wno-sign-compare
 LOCAL_CFLAGS += -Wno-unused-parameter
@@ -162,7 +162,7 @@ ifneq ($(filter msm8992 msm8994 msm8996 msm8998 sdm660 sdm845 apq8098_latv sdm71
 
 include $(CLEAR_VARS)
 
-LOCAL_CFLAGS := -DLIB_AUDIO_HAL="/vendor/lib/hw/audio.primary."$(TARGET_BOARD_PLATFORM)".so"
+LOCAL_CFLAGS := -DPRIMARY_HAL_PLATFORM_NAME=$(TARGET_BOARD_PLATFORM)
 LOCAL_CFLAGS += -Wno-unused-variable
 LOCAL_CFLAGS += -Wno-sign-compare
 LOCAL_CFLAGS += -Wno-unused-parameter

--- a/post_proc/ma_listener.c
+++ b/post_proc/ma_listener.c
@@ -44,7 +44,11 @@
 
 
 #define MA_SET_STATE "audio_hw_send_qdsp_parameter"
+#ifdef __LP64__
+#define HAL_VENDOR_PATH "/vendor/lib64/hw"
+#else
 #define HAL_VENDOR_PATH "/vendor/lib/hw"
+#endif
 
 enum {
     MA_LISTENER_STATE_UNINITIALIZED,

--- a/voice_processing/voice_processing.c
+++ b/voice_processing/voice_processing.c
@@ -32,7 +32,11 @@
 // local definitions
 //------------------------------------------------------------------------------
 
+#ifdef __LP64__
+#define EFFECTS_DESCRIPTOR_LIBRARY_PATH "/vendor/lib64/soundfx/libqcomvoiceprocessingdescriptors.so"
+#else
 #define EFFECTS_DESCRIPTOR_LIBRARY_PATH "/vendor/lib/soundfx/libqcomvoiceprocessingdescriptors.so"
+#endif
 
 // types of pre processing modules
 enum effect_id


### PR DESCRIPTION
We have switched to using a 64-bit audioserver. Update the
soundtrigger hardcoded path to reference the library of
the corresponding architecture.